### PR TITLE
[CORRECTION] Nomme onglet « Vitrine eIDAS-France »

### DIFF
--- a/src/vues/pageAccueil.mustache
+++ b/src/vues/pageAccueil.mustache
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8"/>
-<title>OOTS-France</title>
+<title>Vitrine eIDAS-France</title>
 <link rel="stylesheet" href="/statique/assets/styles/pageAccueil.css">
 
 


### PR DESCRIPTION
<img width="370" alt="Screenshot 2024-06-04 at 11 31 37" src="https://github.com/numerique-gouv/vitrine-eidas/assets/105624/87eff43b-529b-4c11-987d-6a5e8f0c84a2">
