### PR TITLE
Vérification nonce

### DIFF
--- a/mockFCPlus.js
+++ b/mockFCPlus.js
@@ -61,6 +61,7 @@ const enJWE = (cleSignature, infos) => {
 
 const port = 4000;
 const app = express();
+let nonce;
 
 app.use(express.urlencoded({ extended: true }));
 
@@ -78,6 +79,7 @@ app.get('/debut_session', (requete, reponse) => {
   const contexteMock = requete.query.contexte_mock;
   const etat = (contexteMock === 'etatRenvoyeInvalide') ? 'oups' : requete.query.state;
   const code = (contexteMock === 'signatureJetonInvalide') ? 'XXX' : 'abcdef';
+  nonce = (contexteMock === 'nonceInvalide') ? 'oups' : requete.query.nonce;
   reponse.redirect(`${process.env.URL_REDIRECTION_CONNEXION}?state=${etat}&code=${code}`);
 });
 
@@ -89,7 +91,7 @@ app.post('/jeton', (requete, reponse) => {
   const { code } = requete.body;
   const jeton = (code === 'XXX') ? JETON_CAS_SIGNATURE_INVALIDE : 'unJeton';
 
-  enJWE(jwkValide, {})
+  enJWE(jwkValide, { nonce })
     .then((jwe) => reponse.json({ access_token: jeton, id_token: jwe }));
 });
 

--- a/src/api/connexionFCPlus.js
+++ b/src/api/connexionFCPlus.js
@@ -1,15 +1,22 @@
 const { stockeDansCookieSession } = require('../routes/utils');
 
 const connexionFCPlus = (config, code, requete, reponse) => {
-  const { adaptateurChiffrement, fabriqueSessionFCPlus } = config;
+  const { adaptateurChiffrement, adaptateurEnvironnement, fabriqueSessionFCPlus } = config;
 
-  requete.session.jeton = undefined;
+  const secret = adaptateurEnvironnement.secretJetonSession();
 
   return fabriqueSessionFCPlus.nouvelleSession(code)
-    .then((session) => session.enJSON())
-    .then((infos) => stockeDansCookieSession(infos, adaptateurChiffrement, requete))
+    .then((sessionFCPlus) => sessionFCPlus.enJSON())
+    .then((infos) => adaptateurChiffrement.verifieJeton(requete.session.jeton, secret)
+      .then(({ nonce }) => {
+        if (infos.nonce !== nonce) { throw new Error('nonce invalide'); }
+        return stockeDansCookieSession(infos, adaptateurChiffrement, requete);
+      }))
     .then(() => reponse.render('redirectionNavigateur', { destination: '/' }))
-    .catch((e) => reponse.status(502).json({ erreur: `Échec authentification (${e.message})` }));
+    .catch((e) => {
+      requete.session.jeton = undefined;
+      reponse.status(502).json({ erreur: `Échec authentification (${e.message})` });
+    });
 };
 
 module.exports = connexionFCPlus;

--- a/src/api/creationSessionFCPlus.js
+++ b/src/api/creationSessionFCPlus.js
@@ -16,7 +16,7 @@ const creationSessionFCPlus = (config, requete, reponse) => {
     .then((url) => `${url}?scope=profile%20openid%20birthcountry%20birthplace&acr_values=eidas2&claims={%22id_token%22:{%22amr%22:{%22essential%22:true}}}&prompt=login%20consent&response_type=code&idp_hint=${adaptateurEnvironnement.fournisseurIdentiteSuggere()}&client_id=${identifiantClient}&redirect_uri=${urlRedirectionConnexion}&state=${etat}&nonce=${nonce}${paramContexteMock}`);
 
   return stockeDansCookieSession({ etat }, adaptateurChiffrement, requete)
-    .then(() => construisURL())
+    .then(construisURL)
     .then((url) => reponse.render('redirectionNavigateur', { destination: url }));
 };
 

--- a/src/api/creationSessionFCPlus.js
+++ b/src/api/creationSessionFCPlus.js
@@ -15,7 +15,7 @@ const creationSessionFCPlus = (config, requete, reponse) => {
   const construisURL = () => adaptateurFranceConnectPlus.urlCreationSession()
     .then((url) => `${url}?scope=profile%20openid%20birthcountry%20birthplace&acr_values=eidas2&claims={%22id_token%22:{%22amr%22:{%22essential%22:true}}}&prompt=login%20consent&response_type=code&idp_hint=${adaptateurEnvironnement.fournisseurIdentiteSuggere()}&client_id=${identifiantClient}&redirect_uri=${urlRedirectionConnexion}&state=${etat}&nonce=${nonce}${paramContexteMock}`);
 
-  return stockeDansCookieSession({ etat }, adaptateurChiffrement, requete)
+  return stockeDansCookieSession({ etat, nonce }, adaptateurChiffrement, requete)
     .then(construisURL)
     .then((url) => reponse.render('redirectionNavigateur', { destination: url }));
 };

--- a/src/modeles/fabriqueSessionFCPlus.js
+++ b/src/modeles/fabriqueSessionFCPlus.js
@@ -12,7 +12,11 @@ class FabriqueSessionFCPlus {
 
     const conserveJWT = (jwe) => this.adaptateurChiffrement
       .dechiffreJWE(jwe)
-      .then((jwt) => { this.session.jwt = jwt; });
+      .then((jwt) => {
+        this.session.jwt = jwt;
+        return this.adaptateurChiffrement.verifieSignatureJWTDepuisJWKS(jwt);
+      })
+      .then(({ nonce }) => { this.session.nonce = nonce; });
 
     const conserveURLClefsPubliques = () => this.adaptateurFranceConnectPlus
       .recupereURLClefsPubliques()

--- a/src/modeles/sessionFCPlus.js
+++ b/src/modeles/sessionFCPlus.js
@@ -11,6 +11,7 @@ class SessionFCPlus {
 
     this.jetonAcces = undefined;
     this.jwt = undefined;
+    this.nonce = undefined;
     this.urlClefsPubliques = undefined;
   }
 
@@ -28,7 +29,10 @@ class SessionFCPlus {
         jwtInfosUtilisateur,
         this.urlClefsPubliques,
       ))
-      .then((infosDechiffrees) => Object.assign(infosDechiffrees, { jwtSessionFCPlus: this.jwt }))
+      .then((infosDechiffrees) => Object.assign(
+        infosDechiffrees,
+        { jwtSessionFCPlus: this.jwt, nonce: this.nonce },
+      ))
       .catch((e) => Promise.reject(new ErreurEchecAuthentification(e.message)));
   }
 

--- a/src/routes/routesAuth.js
+++ b/src/routes/routesAuth.js
@@ -54,7 +54,7 @@ const routesAuth = (config) => {
     (requete, reponse) => {
       const { code } = requete.query;
       connexionFCPlus(
-        { adaptateurChiffrement, fabriqueSessionFCPlus },
+        { adaptateurChiffrement, adaptateurEnvironnement, fabriqueSessionFCPlus },
         code,
         requete,
         reponse,

--- a/test/api/connexionFCPlus.spec.js
+++ b/test/api/connexionFCPlus.spec.js
@@ -2,13 +2,16 @@ const connexionFCPlus = require('../../src/api/connexionFCPlus');
 
 describe('Le requêteur de connexion FC+', () => {
   const adaptateurChiffrement = {};
+  const adaptateurEnvironnement = {};
   const fabriqueSessionFCPlus = {};
-  const config = { adaptateurChiffrement, fabriqueSessionFCPlus };
+  const config = { adaptateurChiffrement, adaptateurEnvironnement, fabriqueSessionFCPlus };
   const requete = {};
   const reponse = {};
 
   beforeEach(() => {
     adaptateurChiffrement.genereJeton = () => Promise.resolve();
+    adaptateurChiffrement.verifieJeton = () => Promise.resolve({});
+    adaptateurEnvironnement.secretJetonSession = () => '';
     fabriqueSessionFCPlus.nouvelleSession = () => Promise.resolve({
       enJSON: () => Promise.resolve({}),
     });
@@ -35,5 +38,31 @@ describe('Le requêteur de connexion FC+', () => {
     requete.session.jeton = 'unJeton';
     return connexionFCPlus(config, 'unCode', requete, reponse)
       .then(() => expect(requete.session.jeton).toBeUndefined());
+  });
+
+  it('retourne une erreur HTTP 502 si le nonce retourné est différent du nonce en session', () => {
+    expect.assertions(2);
+    adaptateurChiffrement.verifieJeton = () => Promise.resolve({ nonce: 'unNonce' });
+
+    requete.session.jeton = { nonce: 'abcde' };
+    fabriqueSessionFCPlus.nouvelleSession = () => Promise.resolve({
+      enJSON: () => Promise.resolve({ nonce: 'oups' }),
+    });
+
+    reponse.status = (status) => {
+      expect(status).toBe(502);
+      return reponse;
+    };
+
+    reponse.json = (message) => {
+      try {
+        expect(message.erreur).toBe('Échec authentification (nonce invalide)');
+        return Promise.resolve();
+      } catch (e) {
+        return Promise.reject(e);
+      }
+    };
+
+    return connexionFCPlus(config, 'unCode', requete, reponse);
   });
 });

--- a/test/api/creationSessionFCPlus.spec.js
+++ b/test/api/creationSessionFCPlus.spec.js
@@ -87,14 +87,16 @@ describe('Le requêteur de création de session FC+', () => {
     return creationSessionFCPlus(config, requete, reponse);
   });
 
-  it("génère un JWT à partir de la valeur de l'`etat` généré", () => {
-    expect.assertions(1);
+  it('génère un JWT à partir des valeurs générées pour `etat` et `nonce`', () => {
+    expect.assertions(2);
 
-    adaptateurChiffrement.cleHachage = () => '12345';
+    let nbAppelsCleHachage = 0;
+    adaptateurChiffrement.cleHachage = () => { nbAppelsCleHachage += 1; return `12345-${nbAppelsCleHachage}`; };
 
-    adaptateurChiffrement.genereJeton = ({ etat }) => {
+    adaptateurChiffrement.genereJeton = ({ etat, nonce }) => {
       try {
-        expect(etat).toBe('12345');
+        expect(etat).toBe('12345-1');
+        expect(nonce).toBe('12345-2');
         return Promise.resolve();
       } catch (e) {
         return Promise.reject(e);

--- a/test/modeles/fabriqueSessionFCPlus.spec.js
+++ b/test/modeles/fabriqueSessionFCPlus.spec.js
@@ -7,6 +7,7 @@ describe('La fabrique de session FC+', () => {
 
   beforeEach(() => {
     adaptateurChiffrement.dechiffreJWE = () => Promise.resolve('');
+    adaptateurChiffrement.verifieSignatureJWTDepuisJWKS = () => Promise.resolve({});
     adaptateurFranceConnectPlus.recupereDonneesJetonAcces = () => Promise.resolve({});
     adaptateurFranceConnectPlus.recupereURLClefsPubliques = () => Promise.resolve('');
   });
@@ -40,6 +41,22 @@ describe('La fabrique de session FC+', () => {
     const fabrique = new FabriqueSessionFCPlus(config);
     return fabrique.nouvelleSession('unCode')
       .then((session) => expect(session.jwt).toBe('999'));
+  });
+
+  it('conserve le nonce contenu dans le JWT', () => {
+    adaptateurChiffrement.dechiffreJWE = () => Promise.resolve('999');
+    adaptateurChiffrement.verifieSignatureJWTDepuisJWKS = (jwt) => {
+      try {
+        expect(jwt).toBe('999');
+        return Promise.resolve({ nonce: 'abc' });
+      } catch (e) {
+        return Promise.reject(e);
+      }
+    };
+
+    const fabrique = new FabriqueSessionFCPlus(config);
+    return fabrique.nouvelleSession('unCode')
+      .then((session) => expect(session.nonce).toBe('abc'));
   });
 
   it("conserve l'URL des clefs publiques FC+", () => {

--- a/test/modeles/sessionFCPlus.spec.js
+++ b/test/modeles/sessionFCPlus.spec.js
@@ -15,10 +15,13 @@ describe('Une session FranceConnect+', () => {
   const nouvelleSession = ({
     jetonAcces = 'unJetonAcces',
     jwt = 'unJWT',
+    nonce = '',
     urlClefsPubliques = 'uneURL',
   } = {}) => {
     const session = new SessionFCPlus(config);
-    Object.assign(session, { jetonAcces, jwt, urlClefsPubliques });
+    Object.assign(session, {
+      jetonAcces, jwt, nonce, urlClefsPubliques,
+    });
 
     return session;
   };
@@ -92,10 +95,17 @@ describe('Une session FranceConnect+', () => {
       const session = nouvelleSession({ jwt: '999', urlClefsPubliques: 'http://example.com' });
 
       return session.enJSON()
-        .then((json) => expect(json).toEqual({
-          uneClef: 'uneValeur',
-          jwtSessionFCPlus: '999',
-        }));
+        .then((json) => {
+          expect(json).toHaveProperty('uneClef', 'uneValeur');
+          expect(json).toHaveProperty('jwtSessionFCPlus', '999');
+        });
+    });
+
+    it('ajoute le nonce FC+ aux infos utilisateur', () => {
+      const session = nouvelleSession({ nonce: 'abcde' });
+
+      return session.enJSON()
+        .then((json) => expect(json).toHaveProperty('nonce', 'abcde'));
     });
 
     it('lève une `ErreurEchecAuthentification` si une erreur est rencontrée', () => {

--- a/test/routes/serveurTest.js
+++ b/test/routes/serveurTest.js
@@ -19,7 +19,7 @@ const serveurTest = () => {
       cleHachage: () => '',
       dechiffreJWE: () => Promise.resolve(),
       genereJeton: () => Promise.resolve(),
-      verifieJeton: () => Promise.resolve(),
+      verifieJeton: () => Promise.resolve({}),
       verifieSignatureJWTDepuisJWKS: () => Promise.resolve({}),
     };
 


### PR DESCRIPTION
Si le `nonce` généré et transmis à la requête FC+ `/authorize` diffère de celui consigné dans le JWT `id_token` renvoyé par FC+ en réponse à la requête `/token`… on génère une erreur et on interrompt le processus d'identification de l'utilisateur.