### PR TITLE
Affichage d'une page d'erreur

### DIFF
--- a/public/assets/styles/commun.css
+++ b/public/assets/styles/commun.css
@@ -1,0 +1,3 @@
+body {
+  font-family: 'Marianne';
+}

--- a/public/assets/styles/pageAccueil.css
+++ b/public/assets/styles/pageAccueil.css
@@ -1,7 +1,3 @@
-body {
-  font-family: 'Marianne';
-}
-
 .bouton-franceconnect {
     display: block;
     cursor: pointer;

--- a/src/api/connexionFCPlus.js
+++ b/src/api/connexionFCPlus.js
@@ -15,7 +15,7 @@ const connexionFCPlus = (config, code, requete, reponse) => {
     .then(() => reponse.render('redirectionNavigateur', { destination: '/' }))
     .catch((e) => {
       requete.session.jeton = undefined;
-      reponse.status(502).json({ erreur: `Échec authentification (${e.message})` });
+      reponse.render('erreur', { descriptionErreur: `Échec authentification (${e.message})` });
     });
 };
 

--- a/src/routes/routesAuth.js
+++ b/src/routes/routesAuth.js
@@ -39,6 +39,7 @@ const routesAuth = (config) => {
     const { code, state } = requete.query;
     const { error, error_description: descriptionErreur } = requete.query;
     if (typeof error !== 'undefined') {
+      requete.session = null;
       reponse.render('erreur', { descriptionErreur });
     } else if (typeof state === 'undefined' || state === '') {
       reponse.status(400).json({ erreur: "Paramètre 'state' absent de la requête" });

--- a/src/routes/routesAuth.js
+++ b/src/routes/routesAuth.js
@@ -37,7 +37,10 @@ const routesAuth = (config) => {
 
   routes.get('/fcplus/connexion', (requete, reponse) => {
     const { code, state } = requete.query;
-    if (typeof state === 'undefined' || state === '') {
+    const { error, error_description: descriptionErreur } = requete.query;
+    if (typeof error !== 'undefined') {
+      reponse.render('erreur', { descriptionErreur });
+    } else if (typeof state === 'undefined' || state === '') {
       reponse.status(400).json({ erreur: "Paramètre 'state' absent de la requête" });
     } else if (typeof code === 'undefined' || code === '') {
       reponse.status(400).json({ erreur: "Paramètre 'code' absent de la requête" });

--- a/src/vues/erreur.mustache
+++ b/src/vues/erreur.mustache
@@ -1,8 +1,4 @@
-<!DOCTYPE html>
-<meta charset="utf-8">
-<title>Vitrine eIDAS-France</title>
-<link rel="stylesheet" href="/statique/assets/styles/fontes.css">
-<link rel="stylesheet" href="/statique/assets/styles/pageAccueil.css">
+{{>fragments/commun}}
 
 <h1>Une erreur s'est produite</h1>
 <p>{{descriptionErreur}}</p>

--- a/src/vues/erreur.mustache
+++ b/src/vues/erreur.mustache
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Vitrine eIDAS-France</title>
+<link rel="stylesheet" href="/statique/assets/styles/fontes.css">
+<link rel="stylesheet" href="/statique/assets/styles/pageAccueil.css">
+
+<h1>Une erreur s'est produite</h1>
+<p>{{descriptionErreur}}</p>
+
+<p><a href="/">Retourner à l'accueil</a></p>

--- a/src/vues/fragments/commun.mustache
+++ b/src/vues/fragments/commun.mustache
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Vitrine eIDAS-France</title>
+<link rel="stylesheet" href="/statique/assets/styles/fontes.css">
+<link rel="stylesheet" href="/statique/assets/styles/commun.css">
+

--- a/src/vues/pageAccueil.mustache
+++ b/src/vues/pageAccueil.mustache
@@ -1,7 +1,4 @@
-<!DOCTYPE html>
-<meta charset="utf-8">
-<title>Vitrine eIDAS-France</title>
-<link rel="stylesheet" href="/statique/assets/styles/fontes.css">
+{{>fragments/commun}}
 <link rel="stylesheet" href="/statique/assets/styles/pageAccueil.css">
 
 

--- a/src/vues/pageAccueil.mustache
+++ b/src/vues/pageAccueil.mustache
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<meta charset="utf-8"/>
+<meta charset="utf-8">
 <title>Vitrine eIDAS-France</title>
 <link rel="stylesheet" href="/statique/assets/styles/fontes.css">
 <link rel="stylesheet" href="/statique/assets/styles/pageAccueil.css">

--- a/test/api/connexionFCPlus.spec.js
+++ b/test/api/connexionFCPlus.spec.js
@@ -16,7 +16,6 @@ describe('Le requêteur de connexion FC+', () => {
       enJSON: () => Promise.resolve({}),
     });
     requete.session = {};
-    reponse.json = () => Promise.resolve();
     reponse.render = () => Promise.resolve();
     reponse.status = () => reponse;
   });
@@ -40,8 +39,8 @@ describe('Le requêteur de connexion FC+', () => {
       .then(() => expect(requete.session.jeton).toBeUndefined());
   });
 
-  it('retourne une erreur HTTP 502 si le nonce retourné est différent du nonce en session', () => {
-    expect.assertions(2);
+  it("sert une page d'erreur si le nonce retourné est différent du nonce en session", () => {
+    expect.assertions(1);
     adaptateurChiffrement.verifieJeton = () => Promise.resolve({ nonce: 'unNonce' });
 
     requete.session.jeton = { nonce: 'abcde' };
@@ -49,14 +48,9 @@ describe('Le requêteur de connexion FC+', () => {
       enJSON: () => Promise.resolve({ nonce: 'oups' }),
     });
 
-    reponse.status = (status) => {
-      expect(status).toBe(502);
-      return reponse;
-    };
-
-    reponse.json = (message) => {
+    reponse.render = (_nomModelePage, { descriptionErreur }) => {
       try {
-        expect(message.erreur).toBe('Échec authentification (nonce invalide)');
+        expect(descriptionErreur).toBe('Échec authentification (nonce invalide)');
         return Promise.resolve();
       } catch (e) {
         return Promise.reject(e);

--- a/test/routes/routesAuth.spec.js
+++ b/test/routes/routesAuth.spec.js
@@ -41,6 +41,16 @@ describe('Le serveur des routes `/auth`', () => {
       .get(`http://localhost:${port}/auth/fcplus/connexion?error=boum&error_description=oups`)
       .then((reponse) => expect(reponse.data).toContain('oups')));
 
+    it('réinitialise le cookie de session', () => axios
+      .get(`http://localhost:${port}/auth/fcplus/connexion?error=boum&error_description=oups`)
+      .then((reponse) => {
+        expect(reponse.headers).toHaveProperty('set-cookie');
+        const valeurEnteteSetCookie = reponse
+          .headers['set-cookie']
+          .find((h) => h.match(/session=;/));
+        expect(valeurEnteteSetCookie).toContain('session=;');
+      }));
+
     it("sert une erreur HTTP 400 (Bad Request) si le paramètre 'code' est manquant", () => {
       expect.assertions(2);
 

--- a/test/routes/routesAuth.spec.js
+++ b/test/routes/routesAuth.spec.js
@@ -111,18 +111,13 @@ describe('Le serveur des routes `/auth`', () => {
           .catch(leveErreur);
       });
 
-      it("sert une erreur HTTP 502 (Bad Gateway) quand l'authentification échoue", () => {
-        expect.assertions(2);
-
+      it("sert une page d'erreur quand l'authentification échoue", () => {
         serveur.fabriqueSessionFCPlus().nouvelleSession = () => Promise.resolve({
           enJSON: () => Promise.reject(new Error('Oups')),
         });
 
         return axios.get(`http://localhost:${port}/auth/fcplus/connexion_apres_redirection?code=unCode&state=unState`)
-          .catch(({ response }) => {
-            expect(response.status).toBe(502);
-            expect(response.data).toEqual({ erreur: 'Échec authentification (Oups)' });
-          });
+          .then((reponse) => expect(reponse.data).toContain('Échec authentification (Oups)'));
       });
     });
   });

--- a/test/routes/routesAuth.spec.js
+++ b/test/routes/routesAuth.spec.js
@@ -37,6 +37,10 @@ describe('Le serveur des routes `/auth`', () => {
   });
 
   describe('sur GET /auth/fcplus/connexion', () => {
+    it("redirige vers une page d'erreur si le paramètre `error` est présent", () => axios
+      .get(`http://localhost:${port}/auth/fcplus/connexion?error=boum&error_description=oups`)
+      .then((reponse) => expect(reponse.data).toContain('oups')));
+
     it("sert une erreur HTTP 400 (Bad Request) si le paramètre 'code' est manquant", () => {
       expect.assertions(2);
 

--- a/test/routes/routesBase.spec.js
+++ b/test/routes/routesBase.spec.js
@@ -38,6 +38,7 @@ describe('Le serveur des routes `/`', () => {
         })
         .catch(leveErreur);
     });
+
     it("n'affiche pas le bouton quand le feature flip est désactivé", () => {
       expect.assertions(2);
 


### PR DESCRIPTION
<img width="881" alt="Screenshot 2024-06-11 at 11 35 55" src="https://github.com/numerique-gouv/vitrine-eidas/assets/105624/ee2dafcb-def1-4c54-a276-5d3fd0e9842e">

On affiche maintenant les erreurs dans une page dédiée en cas de problème rencontré dans le processus d'identification via FC+ / eIDAS.

Si erreur, le cookie de session est réinitialisé.
