### PR TITLE
Précharge les images de survol

### DIFF
--- a/src/vues/accueil.pug
+++ b/src/vues/accueil.pug
@@ -2,6 +2,8 @@ extends base
 
 block styles
   link(rel='stylesheet', href='/statique/assets/styles/accueil.css')
+  link(rel='preload', href='/statique/assets/images/bouton_survol_france_connect_plus.svg' as='image')
+  link(rel='preload', href='/statique/assets/images/bouton_survol_eIDAS.svg' as='image')
 
 block bandeau
   section


### PR DESCRIPTION
<img width="1371" alt="Screenshot 2024-06-18 at 12 28 20" src="https://github.com/numerique-gouv/vitrine-eidas/assets/2362300/30664a91-8610-4bba-afdc-7c6c2f8af18b">

Précharge les images pour éviter que le chargement ne se fasse quand la souris survole le bouton