### PR TITLE
[CORRECTION] dimensions boutons de connexion

### DIFF
--- a/public/assets/styles/accueil.css
+++ b/public/assets/styles/accueil.css
@@ -29,10 +29,11 @@ section h2 {
   display: block;
   cursor: pointer;
 
-  width: 256px;
-  height: 60px;
+  width: 245px;
+  height: 56px;
   background-repeat: no-repeat;
-  background-size: contain;
+  background-position: center;
+  background-size: cover;
 }
 
 .bouton.franceconnect {
@@ -63,4 +64,8 @@ section h2 {
   mask-size: contain;
   background-color: var(--bleu-titre);
   transform: translateX(.2em) translateY(.25em);
+}
+
+a.description-fcplus {
+  font-size: .9em;
 }

--- a/src/vues/accueil.pug
+++ b/src/vues/accueil.pug
@@ -27,8 +27,9 @@ block page
             FranceConnect+ est la solution proposée par l'État pour renforcer la
             sécurité de vos services en ligne les plus sensibles.
           a.bouton.franceconnect(href = '/auth/fcplus/creationSession')
-          a.nouvel-onglet(href = 'https://franceconnect.gouv.fr/france-connect-plus', target = '_blank').
-            Qu'est-ce que FranceConnect+ ?
+          a.nouvel-onglet.description-fcplus(
+            href = 'https://franceconnect.gouv.fr/france-connect-plus', target = '_blank'
+          ) Qu'est-ce que FranceConnect+ ?
 
   else
     p Pas d'utilisateur courant


### PR DESCRIPTION
<img width="301" alt="Screenshot 2024-06-25 at 14 58 59" src="https://github.com/numerique-gouv/vitrine-eidas/assets/105624/004844ea-52a9-42ac-93c5-241245bbc520">

On en profite pour que cette correction fonctionne pour le bouton FC+ (qui n'a pas les bonnes dimensions 🙄) et pour que le texte en dessous soit correctement aligné.