### PR TITLE
[CORRECTION] Pas d'utilisateur courant si processus authent interrompu

### DIFF
--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -5,6 +5,7 @@ class ErreurEchecAuthentification extends Error {}
 class ErreurInstructionSOAPInconnue extends Error {}
 class ErreurJetonInvalide extends Error {}
 class ErreurReponseRequete extends Error {}
+class ErreurSessionFCPlusInexistante extends Error {}
 
 module.exports = {
   ErreurAbsenceReponseDestinataire,
@@ -14,4 +15,5 @@ module.exports = {
   ErreurInstructionSOAPInconnue,
   ErreurJetonInvalide,
   ErreurReponseRequete,
+  ErreurSessionFCPlusInexistante,
 };

--- a/src/modeles/utilisateur.js
+++ b/src/modeles/utilisateur.js
@@ -1,8 +1,12 @@
+const { ErreurSessionFCPlusInexistante } = require('../erreurs');
+
 class Utilisateur {
   constructor(donnees) {
+    if (typeof donnees.jwtSessionFCPlus === 'undefined') { throw new ErreurSessionFCPlusInexistante(); }
+
+    this.jwtSessionFCPlus = donnees.jwtSessionFCPlus;
     this.prenom = donnees.prenom;
     this.nomUsage = donnees.nomUsage;
-    this.jwtSessionFCPlus = donnees.jwtSessionFCPlus;
   }
 
   afficheToi() {

--- a/test/modeles/utilisateur.spec.js
+++ b/test/modeles/utilisateur.spec.js
@@ -1,8 +1,19 @@
+const { ErreurSessionFCPlusInexistante } = require('../../src/erreurs');
 const Utilisateur = require('../../src/modeles/utilisateur');
 
 describe("L'utilisateur courant", () => {
   it("sait s'afficher", () => {
-    const utilisateur = new Utilisateur({ prenom: 'Juliette', nomUsage: 'Haucourt' });
+    const utilisateur = new Utilisateur({ prenom: 'Juliette', nomUsage: 'Haucourt', jwtSessionFCPlus: 'abcdef' });
     expect(utilisateur.afficheToi()).toBe('Juliette Haucourt');
+  });
+
+  it("vérifie qu'il est initialisé avec un jeton de session FC+", () => {
+    expect.assertions(1);
+
+    try {
+      new Utilisateur({ prenom: 'Juliette', nomUsage: 'Haucourt' });
+    } catch (e) {
+      expect(e).toBeInstanceOf(ErreurSessionFCPlusInexistante);
+    }
   });
 });

--- a/test/routes/middleware.spec.js
+++ b/test/routes/middleware.spec.js
@@ -35,14 +35,21 @@ describe('Le middleware OOTS-France', () => {
   });
 
   it("renseigne les infos de l'utilisateur courant dans la requête", (suite) => {
-    adaptateurChiffrement.verifieJeton = () => Promise.resolve({ prenom: 'Pierre', nomUsage: 'Jax' });
+    adaptateurChiffrement.verifieJeton = () => Promise.resolve({
+      jwtSessionFCPlus: 'abcdef',
+      prenom: 'Pierre',
+      nomUsage: 'Jax',
+    });
 
     const middleware = new Middleware(config);
     expect(requete.utilisateurCourant).toBeUndefined();
 
     middleware.renseigneUtilisateurCourant(requete, null, () => {
       try {
-        expect(requete.utilisateurCourant).toEqual({ prenom: 'Pierre', nomUsage: 'Jax' });
+        const utilisateur = requete.utilisateurCourant;
+        expect(utilisateur.jwtSessionFCPlus).toEqual('abcdef');
+        expect(utilisateur.prenom).toEqual('Pierre');
+        expect(utilisateur.nomUsage).toEqual('Jax');
         suite();
       } catch (e) { suite(e); }
     })

--- a/test/routes/routesBase.spec.js
+++ b/test/routes/routesBase.spec.js
@@ -27,6 +27,7 @@ describe('Le serveur des routes `/`', () => {
     it("affiche prénom et nom de l'utilisateur courant s'il existe", () => {
       serveur.middleware().reinitialise({
         utilisateurCourant: new Utilisateur({
+          jwtSessionFCPlus: 'abcdef',
           prenom: 'Sandra',
           nomUsage: 'Nicouette',
         }),


### PR DESCRIPTION
Jusqu'à présent, si l'utilisateur appuie sur le bouton de connexion, est redirigé vers la mire d'authentification FC+, puis revient avec le bouton « back » du navigateur (avant de s'être authentifié, donc), et qu'on recharge la page, on affiche l'utilisateur courant « undefined undefined », ainsi qu'un lien de déconnexion qui génère une erreur FC+.

Cause : avant d'être redirigé vers la mire d'authentification, on sauve en session un `etat` et un `nonce` utilisés plus tard pour vérifications de cohérence des données reçues de FC+. Le Middleware chargé de mettre en session l'utilisateur courant détecte la présence de ces infos et considère qu'il s'agit d'un utilisateur valide – alors que ce n'est pas le cas.

Cette PR corrige le problème.