### PR TITLE
[CORRECTION] Appel du endpoint FC+ de destruction de session si nonce retourné invalide

### DIFF
--- a/src/api/connexionFCPlus.js
+++ b/src/api/connexionFCPlus.js
@@ -11,7 +11,10 @@ const connexionFCPlus = (config, code, requete, reponse) => {
   const secret = adaptateurEnvironnement.secretJetonSession();
 
   return fabriqueSessionFCPlus.nouvelleSession(code)
-    .then((sessionFCPlus) => sessionFCPlus.enJSON())
+    .then((sessionFCPlus) => {
+      requete.session.jwtSessionFCPlus = sessionFCPlus.jwt;
+      return sessionFCPlus.enJSON();
+    })
     .then((infos) => adaptateurChiffrement.verifieJeton(requete.session.jeton, secret)
       .then(({ nonce }) => {
         if (infos.nonce !== nonce) { throw new Error('nonce invalide'); }

--- a/src/api/destructionSessionFCPlus.js
+++ b/src/api/destructionSessionFCPlus.js
@@ -5,10 +5,9 @@ const destructionSessionFCPlus = (config, requete, reponse) => {
     adaptateurFranceConnectPlus,
   } = config;
 
-  const { utilisateurCourant } = requete;
-  if (!utilisateurCourant) { return reponse.redirect('/auth/fcplus/deconnexion'); }
+  const { jwtSessionFCPlus } = requete.session;
+  if (!jwtSessionFCPlus) { return reponse.redirect('/auth/fcplus/deconnexion'); }
 
-  const { jwtSessionFCPlus } = utilisateurCourant;
   const etat = adaptateurChiffrement.cleHachage(`${Math.random()}`);
   const urlRedirectionDeconnexion = adaptateurEnvironnement.urlRedirectionDeconnexion();
 

--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -5,7 +5,6 @@ class ErreurEchecAuthentification extends Error {}
 class ErreurInstructionSOAPInconnue extends Error {}
 class ErreurJetonInvalide extends Error {}
 class ErreurReponseRequete extends Error {}
-class ErreurSessionFCPlusInexistante extends Error {}
 
 module.exports = {
   ErreurAbsenceReponseDestinataire,
@@ -15,5 +14,4 @@ module.exports = {
   ErreurInstructionSOAPInconnue,
   ErreurJetonInvalide,
   ErreurReponseRequete,
-  ErreurSessionFCPlusInexistante,
 };

--- a/src/modeles/fabriqueSessionFCPlus.js
+++ b/src/modeles/fabriqueSessionFCPlus.js
@@ -8,29 +8,22 @@ class FabriqueSessionFCPlus {
   }
 
   peupleDonneesJetonAcces(code) {
-    const conserveJetonAcces = (jetonAcces) => { this.session.jetonAcces = jetonAcces; };
+    const conserveDansSession = (donnees) => {
+      this.session.jetonAcces = donnees.access_token;
 
-    const conserveJWT = (jwe) => this.adaptateurChiffrement
-      .dechiffreJWE(jwe)
-      .then((jwt) => {
-        this.session.jwt = jwt;
-      });
-
-    const conserveURLClefsPubliques = () => this.adaptateurFranceConnectPlus
-      .recupereURLClefsPubliques()
-      .then((url) => { this.session.urlClefsPubliques = url; });
-
-    const conserveNonce = () => this.adaptateurChiffrement
-      .verifieSignatureJWTDepuisJWKS(this.session.jwt, this.session.urlClefsPubliques)
-      .then(({ nonce }) => { this.session.nonce = nonce; });
+      return Promise.all([
+        this.adaptateurChiffrement.dechiffreJWE(donnees.id_token),
+        this.adaptateurFranceConnectPlus.recupereURLClefsPubliques(),
+      ])
+        .then(([jwt, url]) => {
+          this.session.jwt = jwt;
+          return this.adaptateurChiffrement.verifieSignatureJWTDepuisJWKS(jwt, url);
+        })
+        .then(({ nonce }) => { this.session.nonce = nonce; });
+    };
 
     return this.adaptateurFranceConnectPlus.recupereDonneesJetonAcces(code)
-      .then((donnees) => Promise.all([
-        conserveJetonAcces(donnees.access_token),
-        conserveJWT(donnees.id_token),
-        conserveURLClefsPubliques(),
-      ]))
-      .then(() => conserveNonce());
+      .then(conserveDansSession);
   }
 
   nouvelleSession(code) {

--- a/src/modeles/sessionFCPlus.js
+++ b/src/modeles/sessionFCPlus.js
@@ -12,7 +12,6 @@ class SessionFCPlus {
     this.jetonAcces = undefined;
     this.jwt = undefined;
     this.nonce = undefined;
-    this.urlClefsPubliques = undefined;
   }
 
   enJSON() {
@@ -20,15 +19,11 @@ class SessionFCPlus {
       return Promise.reject(new Error(leveErreurParametreManquant('JWT non défini')));
     }
 
-    if (!this.urlClefsPubliques) {
-      return Promise.reject(new Error(leveErreurParametreManquant('URL clefs publiques non définie')));
-    }
-
-    return this.infosUtilisateurDechiffrees()
-      .then((jwtInfosUtilisateur) => this.adaptateurChiffrement.verifieSignatureJWTDepuisJWKS(
-        jwtInfosUtilisateur,
-        this.urlClefsPubliques,
-      ))
+    return Promise.all([
+      this.infosUtilisateurDechiffrees(),
+      this.adaptateurFranceConnectPlus.recupereURLClefsPubliques(),
+    ])
+      .then(([jwt, url]) => this.adaptateurChiffrement.verifieSignatureJWTDepuisJWKS(jwt, url))
       .then((infosDechiffrees) => ({
         prenom: infosDechiffrees.given_name,
         nomUsage: infosDechiffrees.family_name,

--- a/src/modeles/sessionFCPlus.js
+++ b/src/modeles/sessionFCPlus.js
@@ -32,7 +32,6 @@ class SessionFCPlus {
       .then((infosDechiffrees) => ({
         prenom: infosDechiffrees.given_name,
         nomUsage: infosDechiffrees.family_name,
-        jwtSessionFCPlus: this.jwt,
         nonce: this.nonce,
       }))
       .catch((e) => Promise.reject(new ErreurEchecAuthentification(e.message)));

--- a/src/modeles/utilisateur.js
+++ b/src/modeles/utilisateur.js
@@ -1,10 +1,5 @@
-const { ErreurSessionFCPlusInexistante } = require('../erreurs');
-
 class Utilisateur {
   constructor(donnees) {
-    if (typeof donnees.jwtSessionFCPlus === 'undefined') { throw new ErreurSessionFCPlusInexistante(); }
-
-    this.jwtSessionFCPlus = donnees.jwtSessionFCPlus;
     this.prenom = donnees.prenom;
     this.nomUsage = donnees.nomUsage;
   }

--- a/src/routes/routesAuth.js
+++ b/src/routes/routesAuth.js
@@ -71,7 +71,7 @@ const routesAuth = (config) => {
     deconnexionFCPlus(requete, reponse)
   ));
 
-  routes.get('/fcplus/destructionSession', (...args) => middleware.renseigneUtilisateurCourant(...args), (requete, reponse) => {
+  routes.get('/fcplus/destructionSession', (requete, reponse) => {
     destructionSessionFCPlus(
       {
         adaptateurChiffrement,

--- a/test/api/connexionFCPlus.spec.js
+++ b/test/api/connexionFCPlus.spec.js
@@ -19,6 +19,7 @@ describe('Le requêteur de connexion FC+', () => {
     adaptateurChiffrement.verifieJeton = () => Promise.resolve({});
     adaptateurEnvironnement.secretJetonSession = () => '';
     fabriqueSessionFCPlus.nouvelleSession = () => Promise.resolve({
+      jwt: '',
       enJSON: () => Promise.resolve({}),
     });
     journal.consigne = () => {};
@@ -33,6 +34,18 @@ describe('Le requêteur de connexion FC+', () => {
     expect(requete.session.jeton).toBeUndefined();
     return connexionFCPlus(config, 'unCode', requete, reponse)
       .then(() => expect(requete.session.jeton).toBe('XXX'));
+  });
+
+  it('conserve le JWT de session FC+ dans le cookie de session', () => {
+    fabriqueSessionFCPlus.nouvelleSession = () => Promise.resolve({
+      jwt: 'abcdef',
+      enJSON: () => Promise.resolve({}),
+    });
+
+    expect(requete.session.jwtSessionFCPlus).toBeUndefined();
+
+    return connexionFCPlus(config, 'unCode', requete, reponse)
+      .then(() => expect(requete.session.jwtSessionFCPlus).toBe('abcdef'));
   });
 
   it('supprime le jeton déjà en session sur erreur récupération infos', () => {

--- a/test/api/destructionSessionFCPlus.spec.js
+++ b/test/api/destructionSessionFCPlus.spec.js
@@ -13,14 +13,14 @@ describe('Le requêteur de destruction de session FC+', () => {
     adaptateurChiffrement.cleHachage = () => '';
     adaptateurEnvironnement.urlRedirectionDeconnexion = () => '';
     adaptateurFranceConnectPlus.urlDestructionSession = () => Promise.resolve('');
-    requete = {};
+    requete = { session: {} };
     reponse.end = () => Promise.resolve();
     reponse.redirect = () => Promise.resolve();
   });
 
   describe('quand le JWT de session FC+ existe', () => {
     beforeEach(() => {
-      requete.utilisateurCourant = { jwtSessionFCPlus: '' };
+      requete.session.jwtSessionFCPlus = '12345';
     });
 
     it('redirige vers serveur FC+', () => {
@@ -36,13 +36,13 @@ describe('Le requêteur de destruction de session FC+', () => {
         }
       };
 
-      destructionSessionFCPlus(config, requete, reponse);
+      return destructionSessionFCPlus(config, requete, reponse);
     });
 
     it('récupère le JWT de session FC+ stocké dans la session locale', () => {
       expect.assertions(1);
 
-      requete.utilisateurCourant = { jwtSessionFCPlus: 'abcdef' };
+      requete.session.jwtSessionFCPlus = 'abcdef';
       reponse.redirect = (url) => {
         try {
           expect(url).toContain('id_token_hint=abcdef');
@@ -52,7 +52,7 @@ describe('Le requêteur de destruction de session FC+', () => {
         }
       };
 
-      destructionSessionFCPlus(config, requete, reponse);
+      return destructionSessionFCPlus(config, requete, reponse);
     });
 
     it('ajoute un état en paramètre de la requête', () => {
@@ -68,7 +68,7 @@ describe('Le requêteur de destruction de session FC+', () => {
         }
       };
 
-      destructionSessionFCPlus(config, requete, reponse);
+      return destructionSessionFCPlus(config, requete, reponse);
     });
 
     it("ajoute l'URL de redirection post-logout en paramètre de la requête", () => {
@@ -84,14 +84,14 @@ describe('Le requêteur de destruction de session FC+', () => {
         }
       };
 
-      destructionSessionFCPlus(config, requete, reponse);
+      return destructionSessionFCPlus(config, requete, reponse);
     });
   });
 
   describe('Quand le JWT de session est inexistant', () => {
     it('redirige vers `/auth/fcplus/deconnexion`', () => {
       expect.assertions(2);
-      expect(requete.utilisateurCourant).toBeUndefined();
+      expect(requete.session.jwtSessionFCPlus).toBeUndefined();
 
       reponse.redirect = (url) => {
         try {
@@ -102,7 +102,7 @@ describe('Le requêteur de destruction de session FC+', () => {
         }
       };
 
-      destructionSessionFCPlus(config, requete, reponse);
+      return destructionSessionFCPlus(config, requete, reponse);
     });
   });
 });

--- a/test/modeles/fabriqueSessionFCPlus.spec.js
+++ b/test/modeles/fabriqueSessionFCPlus.spec.js
@@ -58,12 +58,4 @@ describe('La fabrique de session FC+', () => {
     return fabrique.nouvelleSession('unCode')
       .then((session) => expect(session.nonce).toBe('abc'));
   });
-
-  it("conserve l'URL des clefs publiques FC+", () => {
-    adaptateurFranceConnectPlus.recupereURLClefsPubliques = () => Promise.resolve('http://example.com');
-
-    const fabrique = new FabriqueSessionFCPlus(config);
-    return fabrique.nouvelleSession('unCode')
-      .then((session) => expect(session.urlClefsPubliques).toBe('http://example.com'));
-  });
 });

--- a/test/modeles/sessionFCPlus.spec.js
+++ b/test/modeles/sessionFCPlus.spec.js
@@ -10,6 +10,7 @@ describe('Une session FranceConnect+', () => {
     adaptateurChiffrement.dechiffreJWE = () => Promise.resolve('');
     adaptateurChiffrement.verifieSignatureJWTDepuisJWKS = () => Promise.resolve({});
     adaptateurFranceConnectPlus.recupereInfosUtilisateurChiffrees = () => Promise.resolve('');
+    adaptateurFranceConnectPlus.recupereURLClefsPubliques = () => Promise.resolve('');
   });
 
   const nouvelleSession = ({
@@ -81,6 +82,7 @@ describe('Une session FranceConnect+', () => {
 
     it('ajoute les infos utilisateur au cookie de session', () => {
       adaptateurFranceConnectPlus.recupereInfosUtilisateurChiffrees = () => Promise.resolve('aaa');
+      adaptateurFranceConnectPlus.recupereURLClefsPubliques = () => Promise.resolve('http://example.com');
       adaptateurChiffrement.dechiffreJWE = (jwe) => Promise.resolve(jwe);
       adaptateurChiffrement.verifieSignatureJWTDepuisJWKS = (jwt, url) => {
         try {
@@ -92,8 +94,7 @@ describe('Une session FranceConnect+', () => {
         }
       };
 
-      const session = nouvelleSession({ urlClefsPubliques: 'http://example.com' });
-
+      const session = nouvelleSession();
       return session.enJSON()
         .then((json) => {
           expect(json).toHaveProperty('prenom', 'Anne');
@@ -130,16 +131,6 @@ describe('Une session FranceConnect+', () => {
 
       return session.enJSON()
         .catch((e) => expect(e.message).toBe('JWT non défini. La session a-t-elle bien été instanciée depuis la fabrique ?'));
-    });
-
-    it("lève une erreur si l'URL des clefs publiques n'est pas définie", () => {
-      expect.assertions(2);
-
-      const session = nouvelleSession({ urlClefsPubliques: '' });
-      expect(session.urlClefsPubliques).toBeFalsy();
-
-      return session.enJSON()
-        .catch((e) => expect(e.message).toBe('URL clefs publiques non définie. La session a-t-elle bien été instanciée depuis la fabrique ?'));
     });
   });
 });

--- a/test/modeles/sessionFCPlus.spec.js
+++ b/test/modeles/sessionFCPlus.spec.js
@@ -92,13 +92,12 @@ describe('Une session FranceConnect+', () => {
         }
       };
 
-      const session = nouvelleSession({ jwt: '999', urlClefsPubliques: 'http://example.com' });
+      const session = nouvelleSession({ urlClefsPubliques: 'http://example.com' });
 
       return session.enJSON()
         .then((json) => {
           expect(json).toHaveProperty('prenom', 'Anne');
           expect(json).toHaveProperty('nomUsage', 'Durand');
-          expect(json).toHaveProperty('jwtSessionFCPlus', '999');
         });
     });
 

--- a/test/modeles/sessionFCPlus.spec.js
+++ b/test/modeles/sessionFCPlus.spec.js
@@ -79,7 +79,7 @@ describe('Une session FranceConnect+', () => {
         .then(() => expect(signatureVerifiee).toBe(true));
     });
 
-    it('ajoute le JWT de session aux infos utilisateur', () => {
+    it('ajoute les infos utilisateur au cookie de session', () => {
       adaptateurFranceConnectPlus.recupereInfosUtilisateurChiffrees = () => Promise.resolve('aaa');
       adaptateurChiffrement.dechiffreJWE = (jwe) => Promise.resolve(jwe);
       adaptateurChiffrement.verifieSignatureJWTDepuisJWKS = (jwt, url) => {

--- a/test/modeles/utilisateur.spec.js
+++ b/test/modeles/utilisateur.spec.js
@@ -1,19 +1,8 @@
-const { ErreurSessionFCPlusInexistante } = require('../../src/erreurs');
 const Utilisateur = require('../../src/modeles/utilisateur');
 
 describe("L'utilisateur courant", () => {
   it("sait s'afficher", () => {
-    const utilisateur = new Utilisateur({ prenom: 'Juliette', nomUsage: 'Haucourt', jwtSessionFCPlus: 'abcdef' });
+    const utilisateur = new Utilisateur({ prenom: 'Juliette', nomUsage: 'Haucourt' });
     expect(utilisateur.afficheToi()).toBe('Juliette Haucourt');
-  });
-
-  it("vérifie qu'il est initialisé avec un jeton de session FC+", () => {
-    expect.assertions(1);
-
-    try {
-      new Utilisateur({ prenom: 'Juliette', nomUsage: 'Haucourt' });
-    } catch (e) {
-      expect(e).toBeInstanceOf(ErreurSessionFCPlusInexistante);
-    }
   });
 });

--- a/test/routes/middleware.spec.js
+++ b/test/routes/middleware.spec.js
@@ -36,7 +36,6 @@ describe('Le middleware OOTS-France', () => {
 
   it("renseigne les infos de l'utilisateur courant dans la requête", (suite) => {
     adaptateurChiffrement.verifieJeton = () => Promise.resolve({
-      jwtSessionFCPlus: 'abcdef',
       prenom: 'Pierre',
       nomUsage: 'Jax',
     });
@@ -47,7 +46,6 @@ describe('Le middleware OOTS-France', () => {
     middleware.renseigneUtilisateurCourant(requete, null, () => {
       try {
         const utilisateur = requete.utilisateurCourant;
-        expect(utilisateur.jwtSessionFCPlus).toEqual('abcdef');
         expect(utilisateur.prenom).toEqual('Pierre');
         expect(utilisateur.nomUsage).toEqual('Jax');
         suite();

--- a/test/routes/routesAuth.spec.js
+++ b/test/routes/routesAuth.spec.js
@@ -2,7 +2,6 @@ const axios = require('axios');
 
 const { leveErreur } = require('./utils');
 const serveurTest = require('./serveurTest');
-const Utilisateur = require('../../src/modeles/utilisateur');
 
 describe('Le serveur des routes `/auth`', () => {
   const serveur = serveurTest();
@@ -141,20 +140,6 @@ describe('Le serveur des routes `/auth`', () => {
         .then((reponse) => expect(reponse.request.path).toBe('/'))
         .catch(leveErreur)
     ));
-  });
-
-  describe('sur GET /auth/fcplus/destructionSession', () => {
-    it("appelle le middleware pour renseigner les infos de l'utilisateur courant", () => {
-      serveur.middleware().reinitialise({
-        utilisateurCourant: new Utilisateur({ prenom: 'Jean', nomUsage: 'Max', jwtSessionFCPlus: 'abcdef' }),
-      });
-
-      serveur.adaptateurFranceConnectPlus().urlDestructionSession = () => Promise.resolve(`http://localhost:${port}`);
-
-      return axios.get(`http://localhost:${port}/auth/fcplus/destructionSession`)
-        .then((reponse) => expect(reponse.request.path).toContain('id_token_hint=abcdef'))
-        .catch(leveErreur);
-    });
   });
 
   describe('sur GET /auth/fcplus/creationSession', () => {


### PR DESCRIPTION
<img width="441" alt="Screenshot 2024-07-11 at 16 11 07" src="https://github.com/numerique-gouv/vitrine-eidas/assets/105624/fbc54a2d-e798-407e-acbf-09cdc34418c7">

Jusqu'à présent, si le nonce retourné était invalide, on redirigeait vers `GET /auth/fcplus/destructionSessionFCPlus` sans avoir mis les infos utilisateur (dans lequel se trouvait le JWT de session FC+) dans le cookie de session. Ces infos étant inexistantes, on redirigeait directement depuis `destructionSessionFCPlus` vers `deconnexion`, et le endpoint FC+ n'était pas appelé.

Cela nous motive à sortir l'info JWT  de session FC+ hors des infos utilisateur (où on l'avait mis pour gagner du temps), et à commencer à utiliser directement les mécanismes de gestion de cookie de session de express.js (`requete.session.jwtSessionFCPlus = …`) plutôt que de chiffrer à la main.