### PR TITLE
[CORRECTION] N'affiche pas d'infos utilisateur si inexistantes

### DIFF
--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -1,6 +1,7 @@
 class ErreurAbsenceReponseDestinataire extends Error {}
 class ErreurAucunMessageDomibusRecu extends Error {}
 class ErreurDestinataireInexistant extends Error {}
+class ErreurDonneeManquante extends Error {}
 class ErreurEchecAuthentification extends Error {}
 class ErreurInstructionSOAPInconnue extends Error {}
 class ErreurJetonInvalide extends Error {}
@@ -10,6 +11,7 @@ module.exports = {
   ErreurAbsenceReponseDestinataire,
   ErreurAucunMessageDomibusRecu,
   ErreurDestinataireInexistant,
+  ErreurDonneeManquante,
   ErreurEchecAuthentification,
   ErreurInstructionSOAPInconnue,
   ErreurJetonInvalide,

--- a/src/modeles/utilisateur.js
+++ b/src/modeles/utilisateur.js
@@ -1,5 +1,11 @@
+const { ErreurDonneeManquante } = require('../erreurs');
+
 class Utilisateur {
   constructor(donnees) {
+    if (typeof donnees.prenom === 'undefined' && typeof donnees.nomUsage === 'undefined') {
+      throw new ErreurDonneeManquante("Prénom et nom d'usage obligatoires pour instancier un utilisateur");
+    }
+
     this.prenom = donnees.prenom;
     this.nomUsage = donnees.nomUsage;
   }

--- a/test/modeles/utilisateur.spec.js
+++ b/test/modeles/utilisateur.spec.js
@@ -1,8 +1,19 @@
+const { ErreurDonneeManquante } = require('../../src/erreurs');
 const Utilisateur = require('../../src/modeles/utilisateur');
 
 describe("L'utilisateur courant", () => {
   it("sait s'afficher", () => {
     const utilisateur = new Utilisateur({ prenom: 'Juliette', nomUsage: 'Haucourt' });
     expect(utilisateur.afficheToi()).toBe('Juliette Haucourt');
+  });
+
+  it("vérifie qu'il est initialisé avec un nom d'usage et un prénom", () => {
+    expect.assertions(1);
+
+    try {
+      new Utilisateur({});
+    } catch (e) {
+      expect(e).toBeInstanceOf(ErreurDonneeManquante);
+    }
   });
 });


### PR DESCRIPTION
Depuis le dernier commit, on ne vérifiait plus la présent du JWT session FC+ dans les infos utilisateurs (vu qu'il n'y était plus)… mais cette vérification permettait de s'assurer qu'on n'affichait pas d'infos utilisateur si le prénom et nom d'usage était inexistants (cas où l'utilisateur revient sur la page du site vitrine en appuyant sur le bouton « retour arrière » du navigateur – cf [commit 65bfb](https://github.com/numerique-gouv/vitrine-eidas/commit/65bfbfba33e84a0d3c91ac5b3dc75ded737271ec)).

Ce commit corrige la régression.