### PR TITLE
Simplification gestion cookie session

### DIFF
--- a/server.js
+++ b/server.js
@@ -10,7 +10,7 @@ const fabriqueSessionFCPlus = new FabriqueSessionFCPlus({
   adaptateurChiffrement,
   adaptateurFranceConnectPlus,
 });
-const middleware = new Middleware({ adaptateurChiffrement, adaptateurEnvironnement });
+const middleware = new Middleware();
 
 journal.active();
 

--- a/src/adaptateurs/adaptateurChiffrement.js
+++ b/src/adaptateurs/adaptateurChiffrement.js
@@ -11,21 +11,17 @@ const dechiffreJWE = (jwe) => jose
   .then((k) => jose.compactDecrypt(jwe, k))
   .then(({ plaintext }) => plaintext.toString());
 
-const genereJeton = (donnees) => new jose.SignJWT(donnees)
-  .setProtectedHeader({ alg: 'HS256' })
-  .sign(adaptateurEnvironnement.secretJetonSession());
-
-const verifieJeton = (jeton, secret) => {
-  if (typeof jeton === 'undefined') {
-    return Promise.resolve();
-  }
-
-  return jose.jwtVerify(jeton, secret)
-    .then(({ payload }) => payload)
-    .catch((e) => Promise.reject(new ErreurJetonInvalide(e)));
-};
-
 const verifieSignatureJWTDepuisJWKS = (jwt, urlJWKS) => {
+  const verifieJeton = (jeton, secret) => {
+    if (typeof jeton === 'undefined') {
+      return Promise.resolve();
+    }
+
+    return jose.jwtVerify(jeton, secret)
+      .then(({ payload }) => payload)
+      .catch((e) => Promise.reject(new ErreurJetonInvalide(e)));
+  };
+
   const jwks = jose.createRemoteJWKSet(new URL(urlJWKS));
   return verifieJeton(jwt, jwks);
 };
@@ -33,7 +29,5 @@ const verifieSignatureJWTDepuisJWKS = (jwt, urlJWKS) => {
 module.exports = {
   cleHachage,
   dechiffreJWE,
-  genereJeton,
-  verifieJeton,
   verifieSignatureJWTDepuisJWKS,
 };

--- a/src/api/connexionFCPlus.js
+++ b/src/api/connexionFCPlus.js
@@ -1,8 +1,5 @@
-const { stockeDansCookieSession } = require('../routes/utils');
-
 const connexionFCPlus = (config, code, requete, reponse) => {
   const {
-    adaptateurChiffrement,
     fabriqueSessionFCPlus,
     journal,
   } = config;
@@ -14,11 +11,11 @@ const connexionFCPlus = (config, code, requete, reponse) => {
     })
     .then((infos) => {
       if (infos.nonce !== requete.session.nonce) { throw new Error('nonce invalide'); }
-      return stockeDansCookieSession(infos, adaptateurChiffrement, requete);
+      requete.session.infosUtilisateur = infos;
     })
     .then(() => reponse.render('redirectionNavigateur', { destination: '/' }))
     .catch((e) => {
-      requete.session.jeton = undefined;
+      requete.session.infosUtilisateur = undefined;
       journal.consigne(`Échec authentification (${e.message})`);
       reponse.render('redirectionNavigateur', { destination: '/auth/fcplus/destructionSession' });
     });

--- a/src/api/creationSessionFCPlus.js
+++ b/src/api/creationSessionFCPlus.js
@@ -1,5 +1,3 @@
-const { stockeDansCookieSession } = require('../routes/utils');
-
 const creationSessionFCPlus = (config, requete, reponse) => {
   const { adaptateurChiffrement, adaptateurEnvironnement, adaptateurFranceConnectPlus } = config;
 
@@ -19,8 +17,8 @@ const creationSessionFCPlus = (config, requete, reponse) => {
   const construisURL = () => adaptateurFranceConnectPlus.urlCreationSession()
     .then((url) => `${url}?scope=profile%20openid%20birthcountry%20birthplace&acr_values=eidas2&claims={%22id_token%22:{%22amr%22:{%22essential%22:true}}}&prompt=login%20consent&response_type=code&idp_hint=${fournisseurIdentiteSuggere}&client_id=${identifiantClient}&redirect_uri=${urlRedirectionConnexion}&state=${etat}&nonce=${nonce}${paramContexteMock}`);
 
-  return stockeDansCookieSession({ etat, nonce }, adaptateurChiffrement, requete)
-    .then(construisURL)
+  Object.assign(requete.session, { etat, nonce });
+  return construisURL()
     .then((url) => reponse.render('redirectionNavigateur', { destination: url }));
 };
 

--- a/src/routes/middleware.js
+++ b/src/routes/middleware.js
@@ -15,19 +15,14 @@ class Middleware {
       .then(() => suite());
   }
 
-  verifieTamponUnique(requete, reponse, suite) {
-    const valide = (tampon) => {
-      if (tampon.etat !== requete.query.state) {
-        requete.session = null;
-        throw new Error('État invalide');
-      }
-    };
-
-    return this.adaptateurChiffrement.verifieJeton(requete.session.jeton, this.secret)
-      .then(valide)
-      .then(suite)
-      .catch(() => reponse.render('redirectionNavigateur', { destination: '/' }));
-  }
+  verifieTamponUnique = (requete, reponse, suite) => {
+    if (requete.session.etat !== requete.query.state) {
+      requete.session = null;
+      reponse.render('redirectionNavigateur', { destination: '/' });
+    } else {
+      suite();
+    }
+  };
 }
 
 module.exports = Middleware;

--- a/src/routes/middleware.js
+++ b/src/routes/middleware.js
@@ -6,14 +6,15 @@ class Middleware {
     this.secret = config.adaptateurEnvironnement.secretJetonSession();
   }
 
-  renseigneUtilisateurCourant(requete, _reponse, suite) {
-    return this.adaptateurChiffrement.verifieJeton(requete.session.jeton, this.secret)
-      .then((infosUtilisateur) => {
-        requete.utilisateurCourant = new Utilisateur(infosUtilisateur);
-      })
-      .catch(() => { requete.utilisateurCourant = undefined; })
-      .then(() => suite());
-  }
+  renseigneUtilisateurCourant = (requete, _reponse, suite) => {
+    try {
+      requete.utilisateurCourant = new Utilisateur(requete.session.infosUtilisateur);
+    } catch {
+      requete.utilisateurCourant = undefined;
+    }
+
+    suite();
+  };
 
   verifieTamponUnique = (requete, reponse, suite) => {
     if (requete.session.etat !== requete.query.state) {

--- a/src/routes/middleware.js
+++ b/src/routes/middleware.js
@@ -1,11 +1,6 @@
 const Utilisateur = require('../modeles/utilisateur');
 
 class Middleware {
-  constructor(config) {
-    this.adaptateurChiffrement = config.adaptateurChiffrement;
-    this.secret = config.adaptateurEnvironnement.secretJetonSession();
-  }
-
   renseigneUtilisateurCourant = (requete, _reponse, suite) => {
     try {
       requete.utilisateurCourant = new Utilisateur(requete.session.infosUtilisateur);

--- a/src/routes/routesAuth.js
+++ b/src/routes/routesAuth.js
@@ -58,7 +58,6 @@ const routesAuth = (config) => {
     (requete, reponse) => {
       const { code } = requete.query;
       const adaptateurs = {
-        adaptateurChiffrement,
         fabriqueSessionFCPlus,
         journal,
       };

--- a/src/routes/routesAuth.js
+++ b/src/routes/routesAuth.js
@@ -59,7 +59,6 @@ const routesAuth = (config) => {
       const { code } = requete.query;
       const adaptateurs = {
         adaptateurChiffrement,
-        adaptateurEnvironnement,
         fabriqueSessionFCPlus,
         journal,
       };

--- a/src/routes/utils.js
+++ b/src/routes/utils.js
@@ -1,5 +1,0 @@
-const stockeDansCookieSession = (infos, adaptateurChiffrement, requete) => adaptateurChiffrement
-  .genereJeton(infos)
-  .then((jwt) => { requete.session.jeton = jwt; });
-
-module.exports = { stockeDansCookieSession };

--- a/test/api/connexionFCPlus.spec.js
+++ b/test/api/connexionFCPlus.spec.js
@@ -13,15 +13,17 @@ describe('Le requêteur de connexion FC+', () => {
   };
   const requete = {};
   const reponse = {};
+  const sessionFCPlus = {};
 
   beforeEach(() => {
     adaptateurChiffrement.genereJeton = () => Promise.resolve();
     adaptateurChiffrement.verifieJeton = () => Promise.resolve({});
     adaptateurEnvironnement.secretJetonSession = () => '';
-    fabriqueSessionFCPlus.nouvelleSession = () => Promise.resolve({
-      jwt: '',
-      enJSON: () => Promise.resolve({}),
-    });
+
+    sessionFCPlus.jwt = '';
+    sessionFCPlus.enJSON = () => Promise.resolve({});
+    fabriqueSessionFCPlus.nouvelleSession = () => Promise.resolve(sessionFCPlus);
+
     journal.consigne = () => {};
     requete.session = {};
     reponse.render = () => Promise.resolve();
@@ -37,11 +39,7 @@ describe('Le requêteur de connexion FC+', () => {
   });
 
   it('conserve le JWT de session FC+ dans le cookie de session', () => {
-    fabriqueSessionFCPlus.nouvelleSession = () => Promise.resolve({
-      jwt: 'abcdef',
-      enJSON: () => Promise.resolve({}),
-    });
-
+    sessionFCPlus.jwt = 'abcdef';
     expect(requete.session.jwtSessionFCPlus).toBeUndefined();
 
     return connexionFCPlus(config, 'unCode', requete, reponse)
@@ -49,9 +47,7 @@ describe('Le requêteur de connexion FC+', () => {
   });
 
   it('supprime le jeton déjà en session sur erreur récupération infos', () => {
-    fabriqueSessionFCPlus.nouvelleSession = () => Promise.resolve({
-      enJSON: () => Promise.reject(new Error('oups')),
-    });
+    sessionFCPlus.enJSON = () => Promise.reject(new Error('oups'));
     adaptateurChiffrement.genereJeton = () => Promise.resolve('abcdef');
 
     requete.session.jeton = 'unJeton';
@@ -64,9 +60,7 @@ describe('Le requêteur de connexion FC+', () => {
       adaptateurChiffrement.verifieJeton = () => Promise.resolve({ nonce: 'unNonce' });
 
       requete.session.jeton = { nonce: 'abcde' };
-      fabriqueSessionFCPlus.nouvelleSession = () => Promise.resolve({
-        enJSON: () => Promise.resolve({ nonce: 'oups' }),
-      });
+      sessionFCPlus.enJSON = () => Promise.resolve({ nonce: 'oups' });
     });
 
     it("journalise l'erreur", () => {

--- a/test/api/connexionFCPlus.spec.js
+++ b/test/api/connexionFCPlus.spec.js
@@ -2,12 +2,10 @@ const connexionFCPlus = require('../../src/api/connexionFCPlus');
 
 describe('Le requêteur de connexion FC+', () => {
   const adaptateurChiffrement = {};
-  const adaptateurEnvironnement = {};
   const fabriqueSessionFCPlus = {};
   const journal = {};
   const config = {
     adaptateurChiffrement,
-    adaptateurEnvironnement,
     fabriqueSessionFCPlus,
     journal,
   };
@@ -17,8 +15,6 @@ describe('Le requêteur de connexion FC+', () => {
 
   beforeEach(() => {
     adaptateurChiffrement.genereJeton = () => Promise.resolve();
-    adaptateurChiffrement.verifieJeton = () => Promise.resolve({});
-    adaptateurEnvironnement.secretJetonSession = () => '';
 
     sessionFCPlus.jwt = '';
     sessionFCPlus.enJSON = () => Promise.resolve({});
@@ -57,9 +53,7 @@ describe('Le requêteur de connexion FC+', () => {
 
   describe('quand nonce retourné diffère du nonce en session', () => {
     beforeEach(() => {
-      adaptateurChiffrement.verifieJeton = () => Promise.resolve({ nonce: 'unNonce' });
-
-      requete.session.jeton = { nonce: 'abcde' };
+      requete.session.nonce = 'abcde';
       sessionFCPlus.enJSON = () => Promise.resolve({ nonce: 'oups' });
     });
 

--- a/test/api/connexionFCPlus.spec.js
+++ b/test/api/connexionFCPlus.spec.js
@@ -14,8 +14,6 @@ describe('Le requêteur de connexion FC+', () => {
   const sessionFCPlus = {};
 
   beforeEach(() => {
-    adaptateurChiffrement.genereJeton = () => Promise.resolve();
-
     sessionFCPlus.jwt = '';
     sessionFCPlus.enJSON = () => Promise.resolve({});
     fabriqueSessionFCPlus.nouvelleSession = () => Promise.resolve(sessionFCPlus);
@@ -27,11 +25,11 @@ describe('Le requêteur de connexion FC+', () => {
   });
 
   it('conserve les infos utilisateurs dans un cookie de session', () => {
-    adaptateurChiffrement.genereJeton = () => Promise.resolve('XXX');
+    sessionFCPlus.enJSON = () => Promise.resolve({ uneClef: 'une valeur' });
 
-    expect(requete.session.jeton).toBeUndefined();
+    expect(requete.session.infosUtilisateur).toBeUndefined();
     return connexionFCPlus(config, 'unCode', requete, reponse)
-      .then(() => expect(requete.session.jeton).toBe('XXX'));
+      .then(() => expect(requete.session.infosUtilisateur).toEqual({ uneClef: 'une valeur' }));
   });
 
   it('conserve le JWT de session FC+ dans le cookie de session', () => {
@@ -42,13 +40,12 @@ describe('Le requêteur de connexion FC+', () => {
       .then(() => expect(requete.session.jwtSessionFCPlus).toBe('abcdef'));
   });
 
-  it('supprime le jeton déjà en session sur erreur récupération infos', () => {
+  it('supprime les infos utilisateur déjà en session sur erreur récupération des infos', () => {
     sessionFCPlus.enJSON = () => Promise.reject(new Error('oups'));
-    adaptateurChiffrement.genereJeton = () => Promise.resolve('abcdef');
 
-    requete.session.jeton = 'unJeton';
+    requete.session.infosUtilisateur = { uneClef: 'une valeur' };
     return connexionFCPlus(config, 'unCode', requete, reponse)
-      .then(() => expect(requete.session.jeton).toBeUndefined());
+      .then(() => expect(requete.session.infosUtilisateur).toBeUndefined());
   });
 
   describe('quand nonce retourné diffère du nonce en session', () => {

--- a/test/api/creationSessionFCPlus.spec.js
+++ b/test/api/creationSessionFCPlus.spec.js
@@ -86,31 +86,14 @@ describe('Le requêteur de création de session FC+', () => {
     return creationSessionFCPlus(config, requete, reponse);
   });
 
-  it('génère un JWT à partir des valeurs générées pour `etat` et `nonce`', () => {
-    expect.assertions(2);
-
+  it('conserve les valeurs générées pour `etat` et `nonce` dans le cookie de session', () => {
     let nbAppelsCleHachage = 0;
     adaptateurChiffrement.cleHachage = () => { nbAppelsCleHachage += 1; return `12345-${nbAppelsCleHachage}`; };
 
-    adaptateurChiffrement.genereJeton = ({ etat, nonce }) => {
-      try {
-        expect(etat).toBe('12345-1');
-        expect(nonce).toBe('12345-2');
-        return Promise.resolve();
-      } catch (e) {
-        return Promise.reject(e);
-      }
-    };
-
-    return creationSessionFCPlus(config, requete, reponse);
-  });
-
-  it('stocke le JWT généré dans le cookie de session', () => {
-    adaptateurChiffrement.genereJeton = () => Promise.resolve('XXX');
-
-    expect(requete.session.jeton).toBeUndefined();
+    expect(requete.session.etat).toBeUndefined();
+    expect(requete.session.nonce).toBeUndefined();
     return creationSessionFCPlus(config, requete, reponse)
-      .then(() => expect(requete.session.jeton).toBe('XXX'));
+      .then(() => expect(requete.session).toEqual({ etat: '12345-1', nonce: '12345-2' }));
   });
 
   describe('Si utilisation bridge eIDAS', () => {

--- a/test/api/creationSessionFCPlus.spec.js
+++ b/test/api/creationSessionFCPlus.spec.js
@@ -21,7 +21,6 @@ describe('Le requêteur de création de session FC+', () => {
 
   beforeEach(() => {
     adaptateurChiffrement.cleHachage = () => '';
-    adaptateurChiffrement.genereJeton = () => Promise.resolve();
     adaptateurEnvironnement.avecMock = () => false;
     adaptateurEnvironnement.identifiantClient = () => '';
     adaptateurEnvironnement.urlRedirectionConnexion = () => '';

--- a/test/api/deconnexionFCPlus.spec.js
+++ b/test/api/deconnexionFCPlus.spec.js
@@ -11,7 +11,7 @@ describe('Le requêteur de déconnexion FC+', () => {
   });
 
   it('vide le cookie de session', () => {
-    requete.session.jeton = 'unJeton';
+    requete.session = { uneClef: 'une valeur' };
 
     deconnexionFCPlus(requete, reponse);
     expect(requete.session).toBe(null);

--- a/test/routes/middleware.spec.js
+++ b/test/routes/middleware.spec.js
@@ -1,4 +1,3 @@
-const { ErreurJetonInvalide } = require('../../src/erreurs');
 const Middleware = require('../../src/routes/middleware');
 
 describe('Le middleware OOTS-France', () => {
@@ -16,29 +15,8 @@ describe('Le middleware OOTS-France', () => {
     reponse.render = () => Promise.resolve();
   });
 
-  it('vérifie le jeton stocké en session', (suite) => {
-    requete.session.jeton = 'jeton';
-    adaptateurEnvironnement.secretJetonSession = () => 'secret';
-    adaptateurChiffrement.verifieJeton = (jeton, secret) => {
-      try {
-        expect(jeton).toBe('jeton');
-        expect(secret).toBe('secret');
-
-        return Promise.resolve();
-      } catch (e) { return Promise.reject(e); }
-    };
-
-    const middleware = new Middleware(config);
-
-    middleware.renseigneUtilisateurCourant(requete, null, suite)
-      .catch(suite);
-  });
-
   it("renseigne les infos de l'utilisateur courant dans la requête", (suite) => {
-    adaptateurChiffrement.verifieJeton = () => Promise.resolve({
-      prenom: 'Pierre',
-      nomUsage: 'Jax',
-    });
+    requete.session.infosUtilisateur = { prenom: 'Pierre', nomUsage: 'Jax' };
 
     const middleware = new Middleware(config);
     expect(requete.utilisateurCourant).toBeUndefined();
@@ -50,19 +28,19 @@ describe('Le middleware OOTS-France', () => {
         expect(utilisateur.nomUsage).toEqual('Jax');
         suite();
       } catch (e) { suite(e); }
-    })
-      .catch(suite);
+    });
   });
 
-  it("supprime les infos de l'utilisateur courant si le jeton est invalide", (suite) => {
-    adaptateurChiffrement.verifieJeton = () => Promise.reject(new ErreurJetonInvalide('oups'));
+  it("supprime les infos de l'utilisateur courant si les données en session sont invalides", (suite) => {
+    expect(requete.session.infosUtilisateur).toBeUndefined();
 
     const middleware = new Middleware(config);
     middleware.renseigneUtilisateurCourant(requete, null, () => {
-      expect(requete.utilisateurCourant).toBeUndefined();
-      suite();
-    })
-      .catch(suite);
+      try {
+        expect(requete.utilisateurCourant).toBeUndefined();
+        suite();
+      } catch (e) { suite(e); }
+    });
   });
 
   describe('sur demande de vérification du tampon unique', () => {

--- a/test/routes/middleware.spec.js
+++ b/test/routes/middleware.spec.js
@@ -9,7 +9,6 @@ describe('Le middleware OOTS-France', () => {
 
   beforeEach(() => {
     adaptateurEnvironnement.secretJetonSession = () => '';
-    adaptateurChiffrement.verifieJeton = () => Promise.resolve();
 
     requete = { query: {}, session: { jeton: '' } };
     reponse.render = () => Promise.resolve();

--- a/test/routes/middleware.spec.js
+++ b/test/routes/middleware.spec.js
@@ -1,15 +1,10 @@
 const Middleware = require('../../src/routes/middleware');
 
 describe('Le middleware OOTS-France', () => {
-  const adaptateurChiffrement = {};
-  const adaptateurEnvironnement = {};
-  const config = { adaptateurChiffrement, adaptateurEnvironnement };
   const reponse = {};
   let requete;
 
   beforeEach(() => {
-    adaptateurEnvironnement.secretJetonSession = () => '';
-
     requete = { query: {}, session: { jeton: '' } };
     reponse.render = () => Promise.resolve();
   });
@@ -17,7 +12,7 @@ describe('Le middleware OOTS-France', () => {
   it("renseigne les infos de l'utilisateur courant dans la requête", (suite) => {
     requete.session.infosUtilisateur = { prenom: 'Pierre', nomUsage: 'Jax' };
 
-    const middleware = new Middleware(config);
+    const middleware = new Middleware();
     expect(requete.utilisateurCourant).toBeUndefined();
 
     middleware.renseigneUtilisateurCourant(requete, null, () => {
@@ -33,7 +28,7 @@ describe('Le middleware OOTS-France', () => {
   it("supprime les infos de l'utilisateur courant si les données en session sont invalides", (suite) => {
     expect(requete.session.infosUtilisateur).toBeUndefined();
 
-    const middleware = new Middleware(config);
+    const middleware = new Middleware();
     middleware.renseigneUtilisateurCourant(requete, null, () => {
       try {
         expect(requete.utilisateurCourant).toBeUndefined();
@@ -46,7 +41,7 @@ describe('Le middleware OOTS-France', () => {
     it('assure que tampon communiqué identique à celui stocké en session avant de passer à la suite', (suite) => {
       requete.session.etat = '12345';
       requete.query.state = '12345';
-      const middleware = new Middleware(config);
+      const middleware = new Middleware();
 
       middleware.verifieTamponUnique(requete, reponse, suite);
     });
@@ -62,7 +57,7 @@ describe('Le middleware OOTS-France', () => {
 
         reponse.render = (_nomPageRedirection, { destination }) => expect(destination).toBe('/');
 
-        const middleware = new Middleware(config);
+        const middleware = new Middleware();
         middleware.verifieTamponUnique(requete, reponse, () => { throw new Error("Tampon invalide – on n'aurait pas dû passer à la suite"); });
       });
 
@@ -71,7 +66,7 @@ describe('Le middleware OOTS-France', () => {
 
         reponse.render = () => { expect(requete.session).toBe(null); };
 
-        const middleware = new Middleware(config);
+        const middleware = new Middleware();
         middleware.verifieTamponUnique(requete, reponse);
       });
     });

--- a/test/routes/serveurTest.js
+++ b/test/routes/serveurTest.js
@@ -19,8 +19,6 @@ const serveurTest = () => {
     adaptateurChiffrement = {
       cleHachage: () => '',
       dechiffreJWE: () => Promise.resolve(),
-      genereJeton: () => Promise.resolve(),
-      verifieJeton: () => Promise.resolve({}),
       verifieSignatureJWTDepuisJWKS: () => Promise.resolve({}),
     };
 


### PR DESCRIPTION
Jusqu'à présent, on signait manuellement le cookie de session, puis on vérifiait manuellement la signature. Ces deux étapes sont en réalité déjà prises en charge par express.js

Cette PR simplifie la base de code en supprimant ces deux étapes manuelles.