### PR TITLE
Supprime mention OOTS-France

### DIFF
--- a/test/routes/middleware.spec.js
+++ b/test/routes/middleware.spec.js
@@ -1,6 +1,6 @@
 const Middleware = require('../../src/routes/middleware');
 
-describe('Le middleware OOTS-France', () => {
+describe('Le middleware', () => {
   const reponse = {};
   let requete;
 


### PR DESCRIPTION
Il s'agit d'un reliquat datant d'avant la séparation du code de OOTS-France en deux dépôts distincts.