### PR TITLE
Injection jeton d'accès FC+ dans URL requête OOTS

### DIFF
--- a/src/api/connexionFCPlus.js
+++ b/src/api/connexionFCPlus.js
@@ -5,6 +5,7 @@ const connexionFCPlus = (config, requete, reponse) => {
   return fabriqueSessionFCPlus.nouvelleSession(code)
     .then((sessionFCPlus) => {
       requete.session.jwtSessionFCPlus = sessionFCPlus.jwt;
+      requete.session.jetonAcces = sessionFCPlus.jetonAcces;
       return sessionFCPlus.enJSON();
     })
     .then(({ nonce, ...infosUtilisateur }) => {

--- a/src/api/urlOOTS.js
+++ b/src/api/urlOOTS.js
@@ -1,5 +1,5 @@
 const urlOOTS = (adaptateurEnvironnement) => {
-  const urlOOTSRequete = `${adaptateurEnvironnement.urlBaseOOTSFrance()}/requete/pieceJustificative?codeDemarche=00&&codePays=FR`;
+  const urlOOTSRequete = `${adaptateurEnvironnement.urlBaseOOTSFrance()}/requete/pieceJustificative?codeDemarche=00&codePays=FR`;
   return adaptateurEnvironnement.avecOOTS() && urlOOTSRequete;
 };
 

--- a/src/api/urlOOTS.js
+++ b/src/api/urlOOTS.js
@@ -1,0 +1,6 @@
+const urlOOTS = (adaptateurEnvironnement) => {
+  const urlOOTSRequete = `${adaptateurEnvironnement.urlBaseOOTSFrance()}/requete/pieceJustificative?codeDemarche=00&&codePays=FR`;
+  return adaptateurEnvironnement.avecOOTS() && urlOOTSRequete;
+};
+
+module.exports = urlOOTS;

--- a/src/api/urlOOTS.js
+++ b/src/api/urlOOTS.js
@@ -1,5 +1,6 @@
-const urlOOTS = (adaptateurEnvironnement) => {
-  const urlOOTSRequete = `${adaptateurEnvironnement.urlBaseOOTSFrance()}/requete/pieceJustificative?codeDemarche=00&codePays=FR`;
+const urlOOTS = (adaptateurEnvironnement, requete) => {
+  const { jetonAcces } = requete.session;
+  const urlOOTSRequete = `${adaptateurEnvironnement.urlBaseOOTSFrance()}/requete/pieceJustificative?codeDemarche=00&codePays=FR&jetonAcces=${jetonAcces}`;
   return adaptateurEnvironnement.avecOOTS() && urlOOTSRequete;
 };
 

--- a/src/routes/routesBase.js
+++ b/src/routes/routesBase.js
@@ -17,7 +17,7 @@ const routesBase = (config) => {
       const infosUtilisateur = requete.utilisateurCourant;
       reponse.render('accueil', {
         infosUtilisateur,
-        urlOOTS: urlOOTS(adaptateurEnvironnement),
+        urlOOTS: urlOOTS(adaptateurEnvironnement, requete),
       });
     },
   );

--- a/src/routes/routesBase.js
+++ b/src/routes/routesBase.js
@@ -1,5 +1,7 @@
 const express = require('express');
 
+const urlOOTS = require('../api/urlOOTS');
+
 const routesBase = (config) => {
   const {
     adaptateurEnvironnement,
@@ -13,9 +15,10 @@ const routesBase = (config) => {
     (...args) => middleware.renseigneUtilisateurCourant(...args),
     (requete, reponse) => {
       const infosUtilisateur = requete.utilisateurCourant;
-      const urlOOTSRequete = `${adaptateurEnvironnement.urlBaseOOTSFrance()}/requete/pieceJustificative?codeDemarche=00&&codePays=FR`;
-      const urlOOTS = adaptateurEnvironnement.avecOOTS() && urlOOTSRequete;
-      reponse.render('accueil', { infosUtilisateur, urlOOTS });
+      reponse.render('accueil', {
+        infosUtilisateur,
+        urlOOTS: urlOOTS(adaptateurEnvironnement),
+      });
     },
   );
 

--- a/test/api/connexionFCPlus.spec.js
+++ b/test/api/connexionFCPlus.spec.js
@@ -14,6 +14,7 @@ describe('Le requêteur de connexion FC+', () => {
   const sessionFCPlus = {};
 
   beforeEach(() => {
+    sessionFCPlus.jetonAcces = '';
     sessionFCPlus.jwt = '';
     sessionFCPlus.enJSON = () => Promise.resolve({});
     fabriqueSessionFCPlus.nouvelleSession = () => Promise.resolve(sessionFCPlus);
@@ -39,6 +40,14 @@ describe('Le requêteur de connexion FC+', () => {
 
     return connexionFCPlus(config, requete, reponse)
       .then(() => expect(requete.session.jwtSessionFCPlus).toBe('abcdef'));
+  });
+
+  it("conserve le jeton d'accès dans le cookie de session", () => {
+    sessionFCPlus.jetonAcces = 'abcdef';
+    expect(requete.session.jetonAcces).toBeUndefined();
+
+    return connexionFCPlus(config, requete, reponse)
+      .then(() => expect(requete.session.jetonAcces).toBe('abcdef'));
   });
 
   it('supprime les infos utilisateur déjà en session sur erreur récupération des infos', () => {

--- a/test/api/urlOOTS.spec.js
+++ b/test/api/urlOOTS.spec.js
@@ -2,23 +2,32 @@ const urlOOTS = require('../../src/api/urlOOTS');
 
 describe("Le constructeur de l'URL de requête OOTS-France", () => {
   const adaptateurEnvironnement = {};
+  const requete = {};
 
   beforeEach(() => {
     adaptateurEnvironnement.avecOOTS = () => true;
     adaptateurEnvironnement.urlBaseOOTSFrance = () => '';
+    requete.session = {};
   });
 
   it('retourne un lien vers OOTS', () => {
     adaptateurEnvironnement.urlBaseOOTSFrance = () => 'http://example.com';
-    const url = urlOOTS(adaptateurEnvironnement);
+    const url = urlOOTS(adaptateurEnvironnement, requete);
 
     expect(url).toMatch(/^http:\/\/example\.com.*/);
   });
 
   it('retourne `false` si feature flip désactivé', () => {
     adaptateurEnvironnement.avecOOTS = () => false;
-    const url = urlOOTS(adaptateurEnvironnement);
+    const url = urlOOTS(adaptateurEnvironnement, requete);
 
     expect(url).toBe(false);
+  });
+
+  it('injecte jeton accès conservé dans cookie session', () => {
+    requete.session.jetonAcces = 'abcdef';
+    const url = urlOOTS(adaptateurEnvironnement, requete);
+
+    expect(url).toContain('jetonAcces=abcdef');
   });
 });

--- a/test/api/urlOOTS.spec.js
+++ b/test/api/urlOOTS.spec.js
@@ -1,0 +1,24 @@
+const urlOOTS = require('../../src/api/urlOOTS');
+
+describe("Le constructeur de l'URL de requête OOTS-France", () => {
+  const adaptateurEnvironnement = {};
+
+  beforeEach(() => {
+    adaptateurEnvironnement.avecOOTS = () => true;
+    adaptateurEnvironnement.urlBaseOOTSFrance = () => '';
+  });
+
+  it('retourne un lien vers OOTS', () => {
+    adaptateurEnvironnement.urlBaseOOTSFrance = () => 'http://example.com';
+    const url = urlOOTS(adaptateurEnvironnement);
+
+    expect(url).toMatch(/^http:\/\/example\.com.*/);
+  });
+
+  it('retourne `false` si feature flip désactivé', () => {
+    adaptateurEnvironnement.avecOOTS = () => false;
+    const url = urlOOTS(adaptateurEnvironnement);
+
+    expect(url).toBe(false);
+  });
+});


### PR DESCRIPTION
… Afin que OOTS-France puisse appeler le « _token check_ » de FC+ et récupérer les informations d'identité correspondantes.