### PR TITLE
Affiche lien pour consulter document

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.7.4",
+        "body-parser": "^1.20.3",
         "cookie-session": "^2.1.0",
         "diary": "^0.4.5",
         "express": "^4.21.0",
@@ -1739,6 +1740,7 @@
       "version": "1.20.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
       "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
         "content-type": "~1.0.5",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "axios": "^1.7.4",
+    "body-parser": "^1.20.3",
     "cookie-session": "^2.1.0",
     "diary": "^0.4.5",
     "express": "^4.21.0",

--- a/src/api/documentRecu.js
+++ b/src/api/documentRecu.js
@@ -1,0 +1,8 @@
+const documentRecu = (depotDonnees, reponse) => depotDonnees
+  .documentRecu()
+  .then((document) => {
+    reponse.set({ 'content-type': 'application/pdf; charset=utf-8' });
+    reponse.send(document);
+  });
+
+module.exports = documentRecu;

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -11,6 +11,10 @@ class DepotDonnees {
     return Promise.resolve();
   }
 
+  documentRecu() {
+    return Promise.resolve(this.donnees.document);
+  }
+
   reinitialiseRecuperationDocument() {
     this.donnees.statutRecuperationDocument = StatutRecuperationDocument.INITIAL;
     return Promise.resolve();
@@ -20,7 +24,8 @@ class DepotDonnees {
     return Promise.resolve(new StatutRecuperationDocument(this.donnees.statutRecuperationDocument));
   }
 
-  termineRecuperationDocument() {
+  termineRecuperationDocument(document) {
+    this.donnees.document = document;
     this.donnees.statutRecuperationDocument = StatutRecuperationDocument.TERMINE;
     return Promise.resolve();
   }

--- a/src/routes/routesBase.js
+++ b/src/routes/routesBase.js
@@ -1,5 +1,7 @@
 const express = require('express');
 
+const documentRecu = require('../api/documentRecu');
+
 const routesBase = (config) => {
   const {
     adaptateurEnvironnement,
@@ -22,6 +24,8 @@ const routesBase = (config) => {
         }));
     },
   );
+
+  routes.get('/documentRecu', (requete, reponse) => documentRecu(depotDonnees, reponse));
 
   return routes;
 };

--- a/src/routes/routesOOTS.js
+++ b/src/routes/routesOOTS.js
@@ -17,7 +17,7 @@ const routesOOTS = (config) => {
 
   routes.post('/document', (requete, reponse) => {
     if (adaptateurEnvironnement.avecOOTS()) {
-      depotDonnees.termineRecuperationDocument()
+      depotDonnees.termineRecuperationDocument(Buffer.from(requete.body.document))
         .then(() => reponse.send());
     } else {
       reponse.status(501).send('Not Implemented Yet!');

--- a/src/siteVitrine.js
+++ b/src/siteVitrine.js
@@ -1,3 +1,4 @@
+const bodyParser = require('body-parser');
 const cookieSession = require('cookie-session');
 const express = require('express');
 
@@ -17,6 +18,8 @@ const creeServeur = (config) => {
   } = config;
   let serveur;
   const app = express();
+
+  app.use(bodyParser.json());
 
   app.set('trust proxy', 1);
 

--- a/src/vues/accueil.pug
+++ b/src/vues/accueil.pug
@@ -21,7 +21,7 @@ block page
       if statut.estEnCours()
         p Document en cours de récupération
       if statut.estTermine()
-        p Document récupéré !
+        p Document récupéré ! #[a(href = '/documentRecu') (consulter le document)]
       br
 
     a(href = '/auth/fcplus/destructionSession') Déconnexion

--- a/test/api/documentRecu.spec.js
+++ b/test/api/documentRecu.spec.js
@@ -1,0 +1,32 @@
+const documentRecu = require('../../src/api/documentRecu');
+
+describe('Le requêteur du document reçu', () => {
+  const depotDonnees = {};
+  const reponse = {};
+
+  beforeEach(() => {
+    depotDonnees.documentRecu = () => Promise.resolve(Buffer.from(''));
+    reponse.set = () => {};
+    reponse.send = () => {};
+  });
+
+  it('demande le document au dépôt de donnés', () => {
+    let depotDonneesAppele = false;
+    depotDonnees.documentRecu = () => {
+      depotDonneesAppele = true;
+      return Promise.resolve(Buffer.from(''));
+    };
+
+    return documentRecu(depotDonnees, reponse)
+      .then(() => expect(depotDonneesAppele).toBe(true));
+  });
+
+  it('renvoie le document reçu', () => {
+    expect.assertions(1);
+
+    depotDonnees.documentRecu = () => Promise.resolve(Buffer.from('Un document'));
+    reponse.send = (document) => expect(document.toString()).toBe('Un document');
+
+    return documentRecu(depotDonnees, reponse);
+  });
+});

--- a/test/depotDonnees.spec.js
+++ b/test/depotDonnees.spec.js
@@ -25,6 +25,16 @@ describe('Le dépôt de données', () => {
       .then((statut) => expect(statut.estTermine()).toBe(true));
   });
 
+  it('conserve le document reçu', () => {
+    const depot = new DepotDonnees({
+      statutRecuperationDocument: StatutRecuperationDocument.EN_COURS,
+    });
+
+    return depot.termineRecuperationDocument(Buffer.from('Un document'))
+      .then(() => depot.documentRecu())
+      .then((buffer) => expect(buffer.toString()).toBe('Un document'));
+  });
+
   it('repasse le statut de récupération de document à « initial »', () => {
     const depot = new DepotDonnees({
       statutRecuperationDocument: StatutRecuperationDocument.EN_COURS,

--- a/test/routes/routesOOTS.spec.js
+++ b/test/routes/routesOOTS.spec.js
@@ -69,8 +69,19 @@ describe('le serveur des routes `/oots/document`', () => {
         return Promise.resolve();
       };
 
-      return axios.post(`http://localhost:${port}/oots/document`)
+      return axios.post(`http://localhost:${port}/oots/document`, { document: Buffer.from('') })
         .then(() => expect(depotDonneesAppele).toBe(true))
+        .catch(leveErreur);
+    });
+
+    it('conserve le document reçu', () => {
+      expect.assertions(1);
+      serveur.depotDonnees().termineRecuperationDocument = (document) => {
+        expect(document.toString()).toBe('Un document');
+        return Promise.resolve();
+      };
+
+      return axios.post(`http://localhost:${port}/oots/document`, { document: Buffer.from('Un document') })
         .catch(leveErreur);
     });
   });


### PR DESCRIPTION
<img width="653" alt="Screenshot 2024-11-02 at 18 58 39" src="https://github.com/user-attachments/assets/06dfe5c2-cbea-4833-93be-77140f511c9a">

Prochaines étapes : 
- Interdire accès à la requête `GET /documentRecu` si le document n'a pas encore été reçu
- Réinitialiser le document à la déconnexion de l'utilisateur