### PR TITLE
Annule commits transmission jeton acces

### DIFF
--- a/src/api/connexionFCPlus.js
+++ b/src/api/connexionFCPlus.js
@@ -5,7 +5,6 @@ const connexionFCPlus = (config, requete, reponse) => {
   return fabriqueSessionFCPlus.nouvelleSession(code)
     .then((sessionFCPlus) => {
       requete.session.jwtSessionFCPlus = sessionFCPlus.jwt;
-      requete.session.jetonAcces = sessionFCPlus.jetonAcces;
       return sessionFCPlus.enJSON();
     })
     .then(({ nonce, ...infosUtilisateur }) => {

--- a/src/api/urlOOTS.js
+++ b/src/api/urlOOTS.js
@@ -1,6 +1,3 @@
-const urlOOTS = (adaptateurEnvironnement, requete) => {
-  const { jetonAcces } = requete.session;
-  return `${adaptateurEnvironnement.urlBaseOOTSFrance()}/requete/pieceJustificative?codeDemarche=00&codePays=FR&jetonAcces=${jetonAcces}&idRequeteur=${adaptateurEnvironnement.identifiantRequeteur()}`;
-};
+const urlOOTS = (adaptateurEnvironnement) => `${adaptateurEnvironnement.urlBaseOOTSFrance()}/requete/pieceJustificative?codeDemarche=00&codePays=FR&idRequeteur=${adaptateurEnvironnement.identifiantRequeteur()}`;
 
 module.exports = urlOOTS;

--- a/test/api/connexionFCPlus.spec.js
+++ b/test/api/connexionFCPlus.spec.js
@@ -14,7 +14,6 @@ describe('Le requêteur de connexion FC+', () => {
   const sessionFCPlus = {};
 
   beforeEach(() => {
-    sessionFCPlus.jetonAcces = '';
     sessionFCPlus.jwt = '';
     sessionFCPlus.enJSON = () => Promise.resolve({});
     fabriqueSessionFCPlus.nouvelleSession = () => Promise.resolve(sessionFCPlus);
@@ -40,14 +39,6 @@ describe('Le requêteur de connexion FC+', () => {
 
     return connexionFCPlus(config, requete, reponse)
       .then(() => expect(requete.session.jwtSessionFCPlus).toBe('abcdef'));
-  });
-
-  it("conserve le jeton d'accès dans le cookie de session", () => {
-    sessionFCPlus.jetonAcces = 'abcdef';
-    expect(requete.session.jetonAcces).toBeUndefined();
-
-    return connexionFCPlus(config, requete, reponse)
-      .then(() => expect(requete.session.jetonAcces).toBe('abcdef'));
   });
 
   it('supprime les infos utilisateur déjà en session sur erreur récupération des infos', () => {

--- a/test/api/urlOOTS.spec.js
+++ b/test/api/urlOOTS.spec.js
@@ -2,32 +2,23 @@ const urlOOTS = require('../../src/api/urlOOTS');
 
 describe("Le constructeur de l'URL de requête OOTS-France", () => {
   const adaptateurEnvironnement = {};
-  const requete = {};
 
   beforeEach(() => {
     adaptateurEnvironnement.avecOOTS = () => true;
     adaptateurEnvironnement.urlBaseOOTSFrance = () => '';
     adaptateurEnvironnement.identifiantRequeteur = () => '';
-    requete.session = {};
   });
 
   it('retourne un lien vers OOTS', () => {
     adaptateurEnvironnement.urlBaseOOTSFrance = () => 'http://example.com';
-    const url = urlOOTS(adaptateurEnvironnement, requete);
+    const url = urlOOTS(adaptateurEnvironnement);
 
     expect(url).toMatch(/^http:\/\/example\.com.*/);
   });
 
-  it('injecte jeton accès conservé dans cookie session', () => {
-    requete.session.jetonAcces = 'abcdef';
-    const url = urlOOTS(adaptateurEnvironnement, requete);
-
-    expect(url).toContain('jetonAcces=abcdef');
-  });
-
   it("contient l'identifiant de requeteur", () => {
     adaptateurEnvironnement.identifiantRequeteur = () => 'un-identifiant';
-    const url = urlOOTS(adaptateurEnvironnement, requete);
+    const url = urlOOTS(adaptateurEnvironnement);
 
     expect(url).toContain('idRequeteur=un-identifiant');
   });


### PR DESCRIPTION
La manière dont on envisageait de transmettre le jeton d'accès était trop naïve pour fonctionner, car la durée de vie du jeton est inférieure au délai après lequel l'utilisateur commence à interagir avec OOTS.

Ce commit annule cette implémentation naïve.