### PR TITLE
Protège route `GET /oots/callback` par variable environnement `AVEC_OOTS`

### DIFF
--- a/src/routes/routesOOTS.js
+++ b/src/routes/routesOOTS.js
@@ -6,23 +6,13 @@ const routesOOTS = (config) => {
   const { adaptateurEnvironnement, depotDonnees } = config;
   const routes = express.Router();
 
-  routes.get('/document', (requete, reponse) => {
-    if (adaptateurEnvironnement.avecOOTS()) {
-      depotDonnees.demarreRecuperationDocument()
-        .then(() => reponse.render('redirectionNavigateur', { destination: urlOOTS(adaptateurEnvironnement, requete) }));
-    } else {
-      reponse.status(501).send('Not Implemented Yet!');
-    }
-  });
+  routes.get('/document', (requete, reponse) => depotDonnees
+    .demarreRecuperationDocument()
+    .then(() => reponse.render('redirectionNavigateur', { destination: urlOOTS(adaptateurEnvironnement, requete) })));
 
-  routes.post('/document', (requete, reponse) => {
-    if (adaptateurEnvironnement.avecOOTS()) {
-      depotDonnees.termineRecuperationDocument(Buffer.from(requete.body.document))
-        .then(() => reponse.send());
-    } else {
-      reponse.status(501).send('Not Implemented Yet!');
-    }
-  });
+  routes.post('/document', (requete, reponse) => depotDonnees
+    .termineRecuperationDocument(Buffer.from(requete.body.document))
+    .then(() => reponse.send()));
 
   routes.get('/callback', (requete, reponse) => {
     reponse.render('redirectionNavigateur', { destination: '/' });

--- a/src/siteVitrine.js
+++ b/src/siteVitrine.js
@@ -16,6 +16,7 @@ const creeServeur = (config) => {
     journal,
     middleware,
   } = config;
+
   let serveur;
   const app = express();
 
@@ -46,7 +47,13 @@ const creeServeur = (config) => {
     middleware,
   }));
 
-  app.use('/oots', routesOOTS({ adaptateurEnvironnement, depotDonnees }));
+  const protegeRoute = (_requete, reponse, suite) => (
+    adaptateurEnvironnement.avecOOTS()
+      ? suite()
+      : reponse.status(501).send('Not Implemented Yet!')
+  );
+
+  app.use('/oots', protegeRoute, routesOOTS({ adaptateurEnvironnement, depotDonnees }));
 
   app.use('/', routesBase({ adaptateurEnvironnement, depotDonnees, middleware }));
 


### PR DESCRIPTION
… et profitons-en pour réduire de la duplication au passage.