### PR TITLE
Suppression champ `use` de la JWK

### DIFF
--- a/src/routes/routesAuth.js
+++ b/src/routes/routesAuth.js
@@ -25,7 +25,6 @@ const routesAuth = (config) => {
     const clePubliqueDansJWKSet = {
       keys: [{
         kid: idClePublique,
-        use: 'enc',
         kty,
         e,
         n,

--- a/test/routes/routesAuth.spec.js
+++ b/test/routes/routesAuth.spec.js
@@ -26,7 +26,6 @@ describe('Le serveur des routes `/auth`', () => {
             keys: [{
               kid: 'hash de 503as-2qay5...',
               kty: 'RSA',
-              use: 'enc',
               e: 'AQAB',
               n: '503as-2qay5...',
             }],


### PR DESCRIPTION
… Afin qu'elle puisse servir à la fois au chiffrage des informations transmises par FC+, et à la signature des informations envoyées à OOTS-France.