### PR TITLE
Renommage paramètre `utilisateur` en  `beneficiaire` dans requete OOTS

### DIFF
--- a/src/api/urlOOTS.js
+++ b/src/api/urlOOTS.js
@@ -6,7 +6,7 @@ const urlOOTS = (config, requete) => {
     .then((jwe) => {
       const requeteur = adaptateurEnvironnement.identifiantRequeteur();
       const urlOOTSFrance = adaptateurEnvironnement.urlBaseOOTSFrance();
-      return `${urlOOTSFrance}/requete/pieceJustificative?codeDemarche=00&codePays=FR&idRequeteur=${requeteur}&utilisateur=${jwe}`;
+      return `${urlOOTSFrance}/requete/pieceJustificative?codeDemarche=00&codePays=FR&idRequeteur=${requeteur}&utilisateur=${jwe}&beneficiaire=${jwe}`;
     });
 };
 

--- a/test/api/urlOOTS.spec.js
+++ b/test/api/urlOOTS.spec.js
@@ -39,6 +39,9 @@ describe("Le constructeur de l'URL de requête OOTS-France", () => {
     urlOOTS(
       { adaptateurChiffrement, adaptateurEnvironnement },
       requete,
-    ).then((url) => expect(url).toContain('utilisateur=unJeton'));
+    ).then((url) => {
+      expect(url).toContain('beneficiaire=unJeton');
+      expect(url).toContain('utilisateur=unJeton');
+    });
   });
 });

--- a/test/api/urlOOTS.spec.js
+++ b/test/api/urlOOTS.spec.js
@@ -39,6 +39,6 @@ describe("Le constructeur de l'URL de requête OOTS-France", () => {
     urlOOTS(
       { adaptateurChiffrement, adaptateurEnvironnement },
       requete,
-    ).then((url) => expect(url).toContain('unJeton'));
+    ).then((url) => expect(url).toContain('utilisateur=unJeton'));
   });
 });


### PR DESCRIPTION
Note : on garde encore le paramètre `utilisateur` un temps, pour garantir la rétro-compatibilité.